### PR TITLE
state inspection for nodes

### DIFF
--- a/src/Compiler/src/SampleNode.php
+++ b/src/Compiler/src/SampleNode.php
@@ -94,4 +94,12 @@ class SampleNode implements NodeInterface
 
         return $result;
     }
+
+    /**
+     * @return string
+     */
+    public function getState(): string
+    {
+        return $this->state;
+    }
 }


### PR DESCRIPTION
### What was a problem?
While migrating from Hoa compiler to phpltk, we noticed a small issue why we can't migrate with the current release: We were previously able to inspect the current state of a node in the syntax tree. We use this to implement special handling for certain node types in certain places.

Apart from that it was really a pain-free migration, only a few adjustments although we took the chance to clean up our logic a bit ❤️.

### How this PR fixes the problem?
The state of a node is accessible with a public function.