### PR TITLE
Add possible tokens hints.

### DIFF
--- a/libs/buffer/src/ArrayBuffer.php
+++ b/libs/buffer/src/ArrayBuffer.php
@@ -39,6 +39,25 @@ class ArrayBuffer extends Buffer
     }
 
     /**
+     * @param int $key
+     * @return TokenInterface
+     */
+    public function get(int $key): TokenInterface
+    {
+        return $this->buffer[$key];
+    }
+
+    /**
+     * @param int $key
+     * @param $value
+     * @return void
+     */
+    public function set(int $key, $value): void
+    {
+        $this->buffer[$key] = $value;
+    }
+
+    /**
      * @param iterable<TokenInterface> $tokens
      * @return array<positive-int|0, TokenInterface>
      * @psalm-suppress LessSpecificReturnStatement

--- a/libs/buffer/src/ArrayBuffer.php
+++ b/libs/buffer/src/ArrayBuffer.php
@@ -39,25 +39,6 @@ class ArrayBuffer extends Buffer
     }
 
     /**
-     * @param int $key
-     * @return TokenInterface
-     */
-    public function get(int $key): TokenInterface
-    {
-        return $this->buffer[$key];
-    }
-
-    /**
-     * @param int $key
-     * @param $value
-     * @return void
-     */
-    public function set(int $key, $value): void
-    {
-        $this->buffer[$key] = $value;
-    }
-
-    /**
      * @param iterable<TokenInterface> $tokens
      * @return array<positive-int|0, TokenInterface>
      * @psalm-suppress LessSpecificReturnStatement

--- a/libs/buffer/src/MutableBuffer.php
+++ b/libs/buffer/src/MutableBuffer.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Phplrt\Buffer;
+
+use Phplrt\Contracts\Lexer\TokenInterface;
+
+/**
+ * This class is decorator for BufferInterface.
+ * It adds methods for direct read/write elements of buffer.
+ */
+class MutableBuffer implements BufferInterface
+{
+    /**
+     * @var BufferInterface
+     */
+    private BufferInterface $parent;
+
+    /**
+     * @var array
+     */
+    private array $overrides = [];
+
+    /**
+     * @param BufferInterface $parentBuffer
+     */
+    public function __construct(BufferInterface $parentBuffer)
+    {
+        $this->parent = $parentBuffer;
+    }
+
+    /**
+     * @param int $offset
+     * @param TokenInterface $token
+     * @return void
+     */
+    public function set(int $offset, TokenInterface $token): void
+    {
+        $this->overrides[$offset] = $token;
+    }
+
+    /**
+     * @param int $offset
+     * @return TokenInterface
+     */
+    public function get(int $offset): TokenInterface
+    {
+        return $this->overrides[$offset] ?? $this->poll($offset);
+    }
+
+    /**
+     * @param int $offset
+     * @return TokenInterface
+     */
+    private function poll(int $offset): TokenInterface
+    {
+        $previous = $this->parent->key();
+        try {
+            $this->parent->seek($offset);
+            return $this->parent->current();
+        } finally {
+            $this->parent->seek($previous);
+        }
+    }
+
+    /**
+     * @param $offset
+     * @return void
+     */
+    public function seek($offset): void
+    {
+        $this->parent->seek($offset);
+    }
+
+    /**
+     * @return TokenInterface
+     */
+    public function current(): TokenInterface
+    {
+        return $this->overrides[$this->parent->key()] ?? $this->parent->current();
+    }
+
+    /**
+     * @return int
+     */
+    public function key(): int
+    {
+        return $this->parent->key();
+    }
+
+    /**
+     * @return bool
+     */
+    public function valid(): bool
+    {
+        return $this->parent->valid();
+    }
+
+    /**
+     * @return void
+     */
+    public function rewind(): void
+    {
+        $this->parent->rewind();
+    }
+
+    /**
+     * @return void
+     */
+    public function next(): void
+    {
+        $this->parent->next();
+    }
+
+}

--- a/libs/parser/src/Exception/UnexpectedTokenWithHintsException.php
+++ b/libs/parser/src/Exception/UnexpectedTokenWithHintsException.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Phplrt\Parser\Exception;
+
+use Phplrt\Contracts\Lexer\TokenInterface;
+use Phplrt\Contracts\Source\ReadableInterface;
+
+class UnexpectedTokenWithHintsException extends UnexpectedTokenException
+{
+    /**
+     * @param ReadableInterface $src
+     * @param TokenInterface $tok
+     * @param \Throwable|null $prev
+     * @param array $possibleTokens
+     * @return static
+     */
+    public static function fromToken(
+        ReadableInterface $src,
+        TokenInterface $tok,
+        \Throwable $prev = null,
+        array $possibleTokens = []
+    ): self {
+        $errorMessage = (TokenInterface::END_OF_INPUT === $tok->getName())
+            ? 'Unexpected end of code'
+            : self::ERROR_UNRECOGNIZED_TOKEN;
+        $possibleTokensString = '';
+        if (!empty($possibleTokens)) {
+            $possibleTokensString = !empty($possibleTokens)
+                ? 'Expected ' . implode(', ', $possibleTokens) . '. '
+                : '';
+        }
+        $message = \sprintf(
+            $errorMessage . '. '
+            . $possibleTokensString,
+            '"' . $tok->getValue() . '" (' . $tok->getName() . ')'
+        );
+
+        return new static($message, $src, $tok, $prev);
+    }
+}

--- a/libs/parser/src/Parser.php
+++ b/libs/parser/src/Parser.php
@@ -18,8 +18,11 @@ use Phplrt\Contracts\Lexer\LexerInterface;
 use Phplrt\Contracts\Lexer\TokenInterface;
 use Phplrt\Contracts\Parser\ParserInterface;
 use Phplrt\Contracts\Source\ReadableInterface;
+use Phplrt\Lexer\Driver\DriverInterface;
+use Phplrt\Lexer\Token\EndOfInput;
+use Phplrt\Lexer\Token\Token;
 use Phplrt\Parser\Exception\ParserRuntimeException;
-use Phplrt\Parser\Exception\UnexpectedTokenException;
+use Phplrt\Parser\Exception\UnexpectedTokenWithHintsException;
 use Phplrt\Parser\Exception\UnrecognizedTokenException;
 use Phplrt\Parser\Grammar\ProductionInterface;
 use Phplrt\Parser\Grammar\RuleInterface;
@@ -93,6 +96,20 @@ final class Parser implements
      * @var array|RuleInterface[]
      */
     private array $rules;
+
+    /**
+     * Possible tokens searching (enable if it is true)
+     *
+     * @var bool
+     */
+    private bool $possibleTokensSearching = false;
+
+    /**
+     * Array of possible tokens for error or missing token.
+     *
+     * @var array
+     */
+    private array $possibleTokens = [];
 
     /**
      * @param LexerInterface $lexer
@@ -236,9 +253,37 @@ final class Parser implements
             return $result;
         }
 
-        $token = $context->lastOrdinalToken ?? $context->buffer->current();
+        $token = clone($context->lastOrdinalToken ?? $context->buffer->current());
 
-        throw UnexpectedTokenException::fromToken($context->getSource(), $token);
+        if ($this->possibleTokensSearching) {
+            $this->findPossibleTokensForUnexpected($context);
+        }
+
+        throw UnexpectedTokenWithHintsException::fromToken($context->getSource(), $token, null, $this->possibleTokens);
+    }
+
+    /**
+     * @param Context $context
+     * @return void
+     */
+    private function findPossibleTokensForUnexpected(Context $context): void
+    {
+        $problemTokenOffset = $context->lastOrdinalToken->getOffset();
+        $problemTokenKey = 0;
+        while ($context->buffer->get($problemTokenKey)->getOffset() != $problemTokenOffset) {
+            $problemTokenKey++;
+        }
+
+        $context->buffer->set($problemTokenKey, new Token(
+            DriverInterface::UNKNOWN_TOKEN_NAME,
+            '?',
+            $problemTokenOffset
+        ));
+        if ($this->eoi === $context->lastOrdinalToken->getName()) {
+            $context->buffer->set($problemTokenKey + 1, new EndOfInput($problemTokenOffset));
+        }
+
+        $this->next($context);
     }
 
     /**
@@ -277,6 +322,12 @@ final class Parser implements
                     // Rollback previous state
                     [$context->state, $context->lastProcessedToken] = $before;
 
+                    if (DriverInterface::UNKNOWN_TOKEN_NAME === $context->lastProcessedToken->getName()) {
+                        if (!in_array($context->rule->token, $this->possibleTokens)) {
+                            $this->possibleTokens[] = $context->rule->token;
+                        }
+                    }
+
                     return $result;
                 });
 
@@ -294,6 +345,12 @@ final class Parser implements
 
                     if (! $context->rule->isKeep()) {
                         return [];
+                    }
+                }
+
+                if (DriverInterface::UNKNOWN_TOKEN_NAME === $context->lastProcessedToken->getName()) {
+                    if (!in_array($context->rule->token, $this->possibleTokens)) {
+                        $this->possibleTokens[] = $context->rule->token;
                     }
                 }
 

--- a/libs/parser/src/Parser.php
+++ b/libs/parser/src/Parser.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Phplrt\Parser;
 
 use Phplrt\Buffer\BufferInterface;
+use Phplrt\Buffer\MutableBuffer;
 use Phplrt\Contracts\Ast\NodeInterface;
 use Phplrt\Contracts\Exception\RuntimeExceptionInterface;
 use Phplrt\Contracts\Lexer\LexerInterface;
@@ -112,6 +113,11 @@ final class Parser implements
     private array $possibleTokens = [];
 
     /**
+     * @var bool
+     */
+    private bool $useMutableBuffer = false;
+
+    /**
      * @param LexerInterface $lexer
      * @param iterable|RuleInterface[] $grammar
      * @param array $options
@@ -207,7 +213,13 @@ final class Parser implements
 
         $class = $this->buffer;
 
-        return new $class($stream);
+        $buffer = new $class($stream);
+
+        if ($this->useMutableBuffer) {
+            $buffer = new MutableBuffer($buffer);
+        }
+
+        return $buffer;
     }
 
     /**

--- a/libs/parser/src/Parser.php
+++ b/libs/parser/src/Parser.php
@@ -282,7 +282,7 @@ final class Parser implements
     {
         $problemTokenOffset = $context->lastOrdinalToken->getOffset();
         $problemTokenKey = 0;
-        while ($context->buffer->get($problemTokenKey)->getOffset() != $problemTokenOffset) {
+        while ($context->buffer->get($problemTokenKey)->getOffset() !== $problemTokenOffset) {
             $problemTokenKey++;
         }
 

--- a/libs/parser/src/ParserConfigsInterface.php
+++ b/libs/parser/src/ParserConfigsInterface.php
@@ -47,4 +47,9 @@ interface ParserConfigsInterface
      * @var string
      */
     public const CONFIG_STEP_REDUCER = 'step';
+
+    /**
+     * @var string
+     */
+    public const CONFIG_POSSIBLE_TOKENS_SEARCHING = 'possibleTokensSearching';
 }

--- a/libs/parser/src/ParserConfigsTrait.php
+++ b/libs/parser/src/ParserConfigsTrait.php
@@ -86,6 +86,7 @@ trait ParserConfigsTrait
             ->withBuffer($options[Config::CONFIG_BUFFER] ?? $this->buffer)
             ->buildUsing($options[Config::CONFIG_AST_BUILDER] ?? $this)
             ->eachStepThrough($options[Config::CONFIG_STEP_REDUCER] ?? null)
+            ->possibleTokensSearching($options[Config::CONFIG_POSSIBLE_TOKENS_SEARCHING] ?? false)
         ;
     }
 
@@ -148,6 +149,19 @@ trait ParserConfigsTrait
     public function startsAt($initial): self
     {
         $this->initial = $initial;
+
+        return $this;
+    }
+
+    /**
+     * Turn on/off for possible tokens searching
+     *
+     * @param bool $possibleTokensSearching
+     * @return Parser|ParserConfigsTrait
+     */
+    public function possibleTokensSearching(bool $possibleTokensSearching): self
+    {
+        $this->possibleTokensSearching = $possibleTokensSearching;
 
         return $this;
     }

--- a/libs/parser/src/ParserConfigsTrait.php
+++ b/libs/parser/src/ParserConfigsTrait.php
@@ -162,6 +162,7 @@ trait ParserConfigsTrait
     public function possibleTokensSearching(bool $possibleTokensSearching): self
     {
         $this->possibleTokensSearching = $possibleTokensSearching;
+        $this->useMutableBuffer = $this->possibleTokensSearching;
 
         return $this;
     }


### PR DESCRIPTION
Add option to show possible tokens for error message.
Example of error message:
Syntax error, unexpected ";" (T_SEMICOLON). Expected T_BRACKET_CLOSE.