### PR TITLE
Add phplrt agent skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Agent skills (auto-synced by testo/testo on composer update)
 /.agents
+/.claude
 
 # Testing
 /bench.php

--- a/composer.json
+++ b/composer.json
@@ -135,6 +135,11 @@
         "dev:merge": "monorepo-builder merge",
         "dev:syntax": "php libs/components/compiler/bin/build.php"
     },
+    "extra": {
+        "skills": {
+            "source": "skills"
+        }
+    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/libs/components/compiler/composer.json
+++ b/libs/components/compiler/composer.json
@@ -43,10 +43,22 @@
             "Phplrt\\Compiler\\Tests\\": "tests"
         }
     },
+    "suggest": {
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/components/exception/composer.json
+++ b/libs/components/exception/composer.json
@@ -38,10 +38,22 @@
             "Phplrt\\Exception\\Tests\\": "tests"
         }
     },
+    "suggest": {
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/components/lexer-builder/composer.json
+++ b/libs/components/lexer-builder/composer.json
@@ -36,10 +36,22 @@
             "Phplrt\\Lexer\\Builder\\Tests\\": "tests"
         }
     },
+    "suggest": {
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/components/lexer/composer.json
+++ b/libs/components/lexer/composer.json
@@ -40,7 +40,8 @@
         }
     },
     "suggest": {
-        "phplrt/exception": "Renders the syntax errors along with the fragment of the source code they occurred in"
+        "phplrt/exception": "Renders the syntax errors along with the fragment of the source code they occurred in",
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
     },
     "provide": {
         "phplrt/lexer-contracts-implementation": "^4.0"
@@ -49,6 +50,15 @@
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/components/parser-builder/composer.json
+++ b/libs/components/parser-builder/composer.json
@@ -38,10 +38,22 @@
             "Phplrt\\Parser\\Builder\\Tests\\": "tests"
         }
     },
+    "suggest": {
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/components/parser/composer.json
+++ b/libs/components/parser/composer.json
@@ -25,7 +25,8 @@
         "phplrt/source-contracts": "^4.0"
     },
     "suggest": {
-        "phplrt/exception": "Renders the syntax errors along with the fragment of the source code they occurred in"
+        "phplrt/exception": "Renders the syntax errors along with the fragment of the source code they occurred in",
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
     },
     "autoload": {
         "psr-4": {
@@ -51,6 +52,15 @@
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/components/position/composer.json
+++ b/libs/components/position/composer.json
@@ -40,10 +40,22 @@
         "phplrt/position-contracts-implementation": "^4.0",
         "phplrt/position-factory-contracts-implementation": "^4.0"
     },
+    "suggest": {
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/components/source/composer.json
+++ b/libs/components/source/composer.json
@@ -41,10 +41,22 @@
         "phplrt/source-contracts-implementation": "^4.0",
         "phplrt/source-factory-contracts-implementation": "^4.0"
     },
+    "suggest": {
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/contracts/lexer/composer.json
+++ b/libs/contracts/lexer/composer.json
@@ -33,10 +33,22 @@
             "Phplrt\\Contracts\\Lexer\\Tests\\": "tests"
         }
     },
+    "suggest": {
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/contracts/parser/composer.json
+++ b/libs/contracts/parser/composer.json
@@ -34,10 +34,22 @@
             "Phplrt\\Contracts\\Parser\\Tests\\": "tests"
         }
     },
+    "suggest": {
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/contracts/position-factory/composer.json
+++ b/libs/contracts/position-factory/composer.json
@@ -34,10 +34,22 @@
             "Phplrt\\Contracts\\Position\\Tests\\Factory\\": "tests"
         }
     },
+    "suggest": {
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/contracts/position/composer.json
+++ b/libs/contracts/position/composer.json
@@ -32,10 +32,22 @@
             "Phplrt\\Contracts\\Position\\Tests\\": "tests"
         }
     },
+    "suggest": {
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/contracts/source-factory/composer.json
+++ b/libs/contracts/source-factory/composer.json
@@ -33,10 +33,22 @@
             "Phplrt\\Contracts\\Source\\Tests\\Factory\\": "tests"
         }
     },
+    "suggest": {
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/contracts/source/composer.json
+++ b/libs/contracts/source/composer.json
@@ -32,10 +32,22 @@
             "Phplrt\\Contracts\\Source\\Tests\\": "tests"
         }
     },
+    "suggest": {
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/libs/meta/runtime/composer.json
+++ b/libs/meta/runtime/composer.json
@@ -21,10 +21,22 @@
         "phplrt/parser": "^4.0",
         "phplrt/source": "^4.0"
     },
+    "suggest": {
+        "llm/skills": "Delivers the bundled phplrt agent skill (a lexer/parser authoring guide) into your AI coding assistant"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev",
             "dev-main": "4.x-dev"
+        },
+        "skills": {
+            "sources": [
+                {
+                    "from": "github",
+                    "package": "phplrt/phplrt",
+                    "ref": "self.version"
+                }
+            ]
         }
     },
     "config": {

--- a/skills/phplrt/SKILL.md
+++ b/skills/phplrt/SKILL.md
@@ -77,10 +77,15 @@ composer show phplrt/runtime >/dev/null 2>&1 || composer require phplrt/runtime
 # .pp3 + generate (recommended): the compiler is dev-only
 composer show phplrt/compiler >/dev/null 2>&1 || composer require --dev phplrt/compiler
 
-# builder path (prototyping, or a parser assembled dynamically at runtime): dev-only unless
-# you truly build at boot in production, in which case drop --dev for these two
+# lexer branch (tokenizing only, incl. nested sub-lexers via the builder API): the lexer builder alone
+composer show phplrt/lexer-builder >/dev/null 2>&1 || composer require --dev phplrt/lexer-builder
+
+# parser branch (prototyping, or a parser assembled dynamically at runtime): pulls lexer-builder too;
+# dev-only unless you truly build at boot in production, in which case drop --dev
 composer show phplrt/parser-builder >/dev/null 2>&1 || composer require --dev phplrt/parser-builder
 ```
+
+Run the guard for every package the branch's reference file names before writing code that imports it — a feature added mid-task (a nested lexer inside parser work, a `.pp3` generate step after prototyping) re-enters this table with its own row.
 
 ## Mental model
 

--- a/skills/phplrt/SKILL.md
+++ b/skills/phplrt/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: phplrt
+description: Build a lexer/parser for a text format (config, DSL, markup) with phplrt, and ship it right — describe a grammar (`.pp3` file, or `LexerBuilder`/`ParserBuilder` in PHP), GENERATE a committed parser class, and depend only on the runtime; the compiler and builders are dev-only. Use when you must tokenize or parse text into a typed AST. Branches: lexer (reference/lexer.md), parser + reducers (reference/parser.md), the `.pp3` grammar language (reference/pp3.md), nested/embedded lexers (reference/nested.md).
+---
+
+phplrt reads a text format into a value or AST. `LexerBuilder` turns characters into tokens; `ParserBuilder` orders those tokens and runs reducers that build your result; a `.pp3` grammar file is the same thing written as a DSL. Two leading words decide the branch:
+
+- **_lexer_** — cut text into tokens (regex per token, optional sub-lexers).
+- **_parser_** — order those tokens and reduce them into a value/AST.
+
+The full API lives in the source of truth: https://phplrt.org/llms.txt — do not memorize it; read it when a method name is missing. This skill carries only the decisions and gotchas that are not in `--help`.
+
+## Ship the runtime, not the toolchain — read this first
+
+This is the mistake that produces a large pile of code that cannot run in production. Get it right before writing anything.
+
+phplrt splits in two:
+
+- **Runtime** (`phplrt/runtime` = `phplrt/lexer` + `phplrt/parser` + `phplrt/source`) — what a shipped parser needs, and *all* it needs. A shipped parser is a plain PHP class that `extends \Phplrt\Parser\Parser`.
+- **Build-time describers** that turn a grammar into that class: the `.pp3` language read by `phplrt/compiler`, and the in-PHP `phplrt/lexer-builder` + `phplrt/parser-builder`. **Every one of these is a dev dependency.** `phplrt/compiler` alone drags in `laminas/laminas-code`, `symfony/console`, and `twig` — none of which belong in production.
+
+**The anti-pattern (do not do this):** calling `new Compiler()->...->getParser()`, or `$builder->build()->toParser()`, at request time. It forces a describer into `require`, recompiles the whole grammar on every boot, and in a real deploy — where the compiler is `require-dev` and simply isn't installed — fatals with a "class not found". "Give me a parser from what I just built" is a dev-loop convenience, never a shipping architecture.
+
+**The correct flow — generate once, commit the output, depend only on the runtime:**
+
+```bash
+composer require phplrt/runtime            # production
+composer require --dev phplrt/compiler     # dev only
+
+# generate a committed parser from the grammar (dev step; re-run when the grammar changes)
+vendor/bin/phplrt check grammar.pp3 -v   # exit 0 = the grammar compiles; read the numbers (see pp3.md)
+vendor/bin/phplrt compile grammar.pp3 src/MyParser.php \
+    --class=MyParser --namespace='App\Parser'
+```
+
+```php
+// runtime: no compiler, no builders, no laminas/symfony/twig
+$parser = new App\Parser\MyParser();
+$ast = $parser->parse(Phplrt\Source\StringSource::createFromString($input));
+```
+
+The generated class inlines the whole lexer as one regex and every reducer as a real method you can step through — there is no hidden runtime compilation left. `new Compiler()->load(new FileSource('grammar.pp3'))->generate()->withClassName(...)->withNamespaceName(...)->save('src/MyParser.php')` is the same thing from PHP if you would rather generate from a build script than the CLI.
+
+**Corollary — don't fight the codegen.** If you compile a grammar into a `ParserBuilderResult` and then bolt a hand-written lexer onto it at runtime, or keep a static-cached `getParser()`, you have turned a code generator into a runtime interpreter — the same dead-weight trap, most of the code doing work `save()` would have done once. Put the hand-written lexer *inside* the grammar (`%lexer name -> { new App\MyLexer() }`, or a lexer state — see `reference/nested.md`) so one generated class is self-contained, then generate it. And reduce rules into **typed AST nodes**, not one generic catch-all node — a parser that returns a single `Node` type for everything threw away the structure that was the point of parsing.
+
+The in-PHP builders are for prototyping a grammar and for the rare parser assembled dynamically at runtime. If you truly ship builder-constructed parsers you accept `phplrt/lexer-builder` + `phplrt/parser-builder` as runtime deps and a per-boot build — lighter than the compiler, still not the default. When in doubt: `.pp3` + generate.
+
+## Pre-flight — install what you use
+
+Phplrt is split into components; each class lives in its own package. A "class not found" is a missing package, not a typo — install only what the branch needs before writing code. Check first, install only if absent (the guard avoids needless network churn; `composer require` is otherwise a no-op when present).
+
+**Split it by where it runs (see "Ship the runtime" above):** the describer packages below — the `*-builder` pair and `phplrt/compiler` — are **dev** dependencies (`--dev`); production needs only `phplrt/runtime`. The one exception is a parser you genuinely assemble with the builders at runtime, which then keeps the `*-builder` pair in `require`.
+
+### Lock the toolchain (PHP + composer)
+
+Resolve the PHP and composer binaries **once, in this preparatory phase**, and reuse the absolute paths everywhere — including inside subagents, which may not share the parent shell's `PATH` and would otherwise fail with `php: command not found`.
+
+```bash
+PHP_BIN="$(command -v php || command -v php8.4 || command -v php8.3)"
+COMPOSER="$(command -v composer || echo "$PHP_BIN $(command -v composer.phar)")"
+"$PHP_BIN" -v   # confirm it actually runs
+```
+
+Pass `$PHP_BIN` (and `$COMPOSER`) to every subagent you dispatch, and invoke PHP as `"$PHP_BIN" script.php` rather than bare `php`, so execution is deterministic and survives a subagent's narrower environment. Use `$COMPOSER` in place of `composer` in the install steps below.
+
+| You use | Package | Scope | Pulls in |
+|---|---|---|---|
+| A generated/shipped parser (`extends \Phplrt\Parser\Parser`), `StringSource`, `FileSource` | `phplrt/runtime` | **runtime** (`require`) | `phplrt/lexer` + `phplrt/parser` + `phplrt/source` |
+| `LexerBuilder`, `RuntimeLexerTransformer`, `RegexModifier`, `TokenDefinition` | `phplrt/lexer-builder` | dev (`--dev`) | `phplrt/lexer` |
+| `ParserBuilder` | `phplrt/parser-builder` | dev (`--dev`) | `phplrt/lexer-builder`, `phplrt/lexer`, `phplrt/parser` |
+| `.pp3` `Compiler`, `vendor/bin/phplrt compile` (codegen) | `phplrt/compiler` | dev (`--dev`) | all of the above **+ laminas-code, symfony/console, twig** |
+
+```bash
+# always: the runtime ships to production
+composer show phplrt/runtime >/dev/null 2>&1 || composer require phplrt/runtime
+
+# .pp3 + generate (recommended): the compiler is dev-only
+composer show phplrt/compiler >/dev/null 2>&1 || composer require --dev phplrt/compiler
+
+# builder path (prototyping, or a parser assembled dynamically at runtime): dev-only unless
+# you truly build at boot in production, in which case drop --dev for these two
+composer show phplrt/parser-builder >/dev/null 2>&1 || composer require --dev phplrt/parser-builder
+```
+
+## Mental model
+
+1. Declare tokens: `$lexer->addPattern('\d+', 'T_NUMBER')` — the pattern is a raw PCRE body, **no delimiters** (patterns are spliced into one alternation, so a `#...#` wrapper would become literal characters). **Declaration order wins, not length** — the lexer tries patterns in the order they were added and takes the first one that matches at the current position (verified against `MarkersRegexGenerator`: it compiles a single PCRE alternation, and PCRE alternation is leftmost-first). Put a keyword or a multi-char operator *before* the generic pattern it would otherwise be swallowed by (an identifier, a single-char operator) — length never rescues a rule declared too late.
+2. Declare rules + reducers: `$builder->addTokenReference('T_FOO')->setReducer(fn($ctx, $tok) => ...)`.
+3. Wire: build the lexer, transform it, hand it to the parser, parse a `StringSource`.
+4. **Ship:** generate the wired parser into a committed class and depend only on the runtime (see "Ship the runtime"). Steps 1–3 are the dev loop, not the deploy artifact.
+
+## Prototype end-to-end (the dev loop)
+
+This builds a parser in-process — right for iterating on a grammar, wrong to leave in shipped code (it keeps the builders in `require` and rebuilds every call). Once the grammar is settled, express it as `.pp3` and generate a committed parser class instead.
+
+```php
+use Phplrt\Lexer\Builder\LexerBuilder;
+use Phplrt\Lexer\Builder\Transformer\RuntimeLexerTransformer;
+use Phplrt\Parser\Builder\ParserBuilder;
+use Phplrt\Source\StringSource;
+
+$lexer = new LexerBuilder();
+$lexer->addPattern('\d+', 'T_NUMBER');
+$lexer->addPattern('\+', 'T_PLUS');
+$lexer->addPattern('\s+')->hide();            // skipped, not dropped
+
+$builder = new ParserBuilder();
+$number = $builder->addTokenReference('T_NUMBER')
+    ->setReducer(static fn($ctx, $tok) => (int) $tok->value);
+$plus = $builder->addTokenReference('T_PLUS');
+// every array element must be a RuleDefinition — a bare string throws a TypeError
+$sum = $builder->addConcatenation([$number, $plus, $number])
+    ->setReducer(static fn($ctx, $kids) => $kids[0] + $kids[2]);
+$builder->setInitialRule($sum);
+
+$lexerResult = $lexer->build();
+$runtimeLexer = (new RuntimeLexerTransformer())->transform($lexerResult);
+$parser = $builder->build($lexerResult)->toParser($runtimeLexer);
+
+$result = $parser->parse(StringSource::createFromString('12 + 30')); // 42
+```
+
+The same grammar as a committed, runtime-only parser: write the tokens/rules as `grammar.pp3`, then `vendor/bin/phplrt compile grammar.pp3 src/SumParser.php --class=SumParser --namespace='App'` and ship `new App\SumParser()`. See "Ship the runtime".
+
+## Gotchas — the cache (read before debugging)
+
+These are the non-obvious bits that cost hours; they are not spelled out by the API surface.
+
+- **Compiling at request time is the one that wastes a whole deliverable, not just hours** — see "Ship the runtime". If most of your parser code is wiring builders together at boot, that code is the thing `save()` replaces.
+- **DotAll is on by default.** `.` matches newlines. For line-based lexing call `$lexer->disable(RegexModifier::DotAll)`. `^`/`$` match line starts by default (PCRE multiline), so anchor block patterns with `^`.
+- **Reducer value shape depends on the rule type.** A `Concatenation`/`Repetition` (a `SequenceInterface`) passes a **flat array** of child values. An `Alternation`/`Optional`/`Terminal` passes a **single** value (or `[]` when absent); a kept terminal passes the `TokenInterface`. Never assume an array for a terminal.
+- **A sequence's array is flattened one level into whatever contains it — including a nested rule's own array.** If rule B (a Concatenation/Repetition) sits inside rule A's own Concatenation/Repetition, B's array does not arrive as one element of A's array — it is spread into it, so A can no longer tell where B's own children ended. A rule that must produce a group of its own has to say so with a reducer that returns something that is *not* a bare array — an object, or a scalar — since only an array gets flattened this way. This bit harder than the shape rule above because it only shows up once a grammar nests two levels deep.
+- **`addRepetition($rule, $max = INF, $min = 0, $name = null)` — the name is the 4th argument.** Write `->addRepetition($rule, min: 1, name: 'Foo')`. With `min: 0` the optimizer may drop a nullable alternative; use `min: 1` to keep it.
+- **`addConcatenation(array $rules = [], ?string $name = null)` and `addAlternation(array $rules = [], ?string $name = null)` take the name as the 2nd argument.**
+- **Nested lexers: the parser never sees inner tokens by name.** `->enter('lang')` makes the opening token a `TokenEmbedding`; walk `$token->children` (each child has `->name` and `->value`). Reference the opening `TokenDefinition` object, not the inner token. See `reference/nested.md`.
+- **Hidden tokens (`->hide()`) leave the parser stream but stay inside an embedding's children** if a sub-lexer produced them — so a hidden frontmatter comment can still surface in `$token->children`; skip it by name in the reducer.
+- **Reference tokens by the `TokenDefinition` returned by `addPattern`/`addTokenReference`** when you can; string names work but the object form never silently mismatches ("token not recognized").
+- **PEG semantics, in the builders and in `.pp3` alike:** choice is ordered (`a | ab` never reads `ab` — longer alternative first), left recursion is refused at compile time (rewrite as a repetition), and the whole input must be consumed — trailing junk is a syntax error, not a stopping point. Details: `reference/pp3.md`.
+
+## Definition of done — the parser ships only when all of these hold
+
+Each criterion is an exit code, not a judgement call. A "done" that skipped one of these is the anti-pattern from "Ship the runtime" wearing a green checkmark.
+
+1. **The grammar compiles:** `vendor/bin/phplrt check grammar.pp3 -v` exits 0. Read the `-v` numbers: `Rules: Loaded/After` collapsing to almost nothing means the root is wrong (`%pragma root` — see `reference/pp3.md`), not a good optimization.
+2. **The committed parser is not stale:** re-run the exact `compile` command, then `git diff --exit-code -- src/MyParser.php` passes. A grammar edit without a regenerate fails right here — that is the check working, not an obstacle.
+3. **Production is builder-free:** the describers sit in `require-dev` only, and nothing under `src/` references `Compiler`, `LexerBuilder`, or `ParserBuilder`. `composer show phplrt/runtime` succeeds.
+4. **The committed class parses:** at least one test constructs the generated parser (`new App\Parser\MyParser()` — not a freshly built one) and asserts on the typed AST from a representative input.
+
+Wire 1 and 2 into `composer.json` scripts (`grammar:check` / `grammar:build`) and CI, so the day someone edits the grammar and forgets to rebuild fails in the pull request instead of production. The full GitHub Actions / GitLab CI recipe lives at https://phplrt.org/llms.txt (Automation and CI); checking many grammars in one job needs `xargs`, not `find -exec` (find exits 0 even when a grammar fails).
+
+## Reference files (loaded on demand)
+
+- Lexer-only work, PCRE modifiers, channels: `reference/lexer.md`.
+- Rules, reducers, the nested inline-parser trick: `reference/parser.md`.
+- The `.pp3` grammar language — tokens, rules, reducers, `%pragma`, states: `reference/pp3.md`.
+- Frontmatter / fenced code / strings via embedded lexers, plus hand-written `LexerInterface` lexers for indentation-sensitive nesting a regex sub-lexer can't express: `reference/nested.md`.
+- Full API, examples (JSON, Cron, URL): https://phplrt.org/llms.txt.

--- a/skills/phplrt/SKILL.md
+++ b/skills/phplrt/SKILL.md
@@ -24,8 +24,8 @@ phplrt splits in two:
 **The correct flow — generate once, commit the output, depend only on the runtime:**
 
 ```bash
-composer require phplrt/runtime            # production
-composer require --dev phplrt/compiler     # dev only
+composer require phplrt/runtime            # production   (ask the user first — see Pre-flight)
+composer require --dev phplrt/compiler     # dev only     (ask the user first — see Pre-flight)
 
 # generate a committed parser from the grammar (dev step; re-run when the grammar changes)
 vendor/bin/phplrt check grammar.pp3 -v   # exit 0 = the grammar compiles; read the numbers (see pp3.md)
@@ -47,7 +47,7 @@ The in-PHP builders are for prototyping a grammar and for the rare parser assemb
 
 ## Pre-flight — install what you use
 
-Phplrt is split into components; each class lives in its own package. A "class not found" is a missing package, not a typo — install only what the branch needs before writing code. Check first, install only if absent (the guard avoids needless network churn; `composer require` is otherwise a no-op when present).
+Phplrt is split into components; each class lives in its own package. A "class not found" is a missing package, not a typo — sort out what the branch needs before writing code. Checking is yours; **installing is the user's call — never run `composer require` without asking them first.** When a package the branch needs is missing, stop and ask, naming the package, its scope (`--dev` or runtime), and one line of why — what class or step needs it and what it drags in, both straight from the table below. Install only after they agree.
 
 **Split it by where it runs (see "Ship the runtime" above):** the describer packages below — the `*-builder` pair and `phplrt/compiler` — are **dev** dependencies (`--dev`); production needs only `phplrt/runtime`. The one exception is a parser you genuinely assemble with the builders at runtime, which then keeps the `*-builder` pair in `require`.
 
@@ -70,22 +70,23 @@ Pass `$PHP_BIN` (and `$COMPOSER`) to every subagent you dispatch, and invoke PHP
 | `ParserBuilder` | `phplrt/parser-builder` | dev (`--dev`) | `phplrt/lexer-builder`, `phplrt/lexer`, `phplrt/parser` |
 | `.pp3` `Compiler`, `vendor/bin/phplrt compile` (codegen) | `phplrt/compiler` | dev (`--dev`) | all of the above **+ laminas-code, symfony/console, twig** |
 
+**Step 1 — check what the branch needs (read-only, run freely):**
+
 ```bash
-# always: the runtime ships to production
-composer show phplrt/runtime >/dev/null 2>&1 || composer require phplrt/runtime
-
-# .pp3 + generate (recommended): the compiler is dev-only
-composer show phplrt/compiler >/dev/null 2>&1 || composer require --dev phplrt/compiler
-
-# lexer branch (tokenizing only, incl. nested sub-lexers via the builder API): the lexer builder alone
-composer show phplrt/lexer-builder >/dev/null 2>&1 || composer require --dev phplrt/lexer-builder
-
-# parser branch (prototyping, or a parser assembled dynamically at runtime): pulls lexer-builder too;
-# dev-only unless you truly build at boot in production, in which case drop --dev
-composer show phplrt/parser-builder >/dev/null 2>&1 || composer require --dev phplrt/parser-builder
+composer show phplrt/runtime        >/dev/null 2>&1 || echo "missing: phplrt/runtime"        # always
+composer show phplrt/compiler      >/dev/null 2>&1 || echo "missing: phplrt/compiler"       # .pp3 + generate branch
+composer show phplrt/lexer-builder >/dev/null 2>&1 || echo "missing: phplrt/lexer-builder"   # lexer branch (incl. nested sub-lexers)
+composer show phplrt/parser-builder >/dev/null 2>&1 || echo "missing: phplrt/parser-builder" # parser branch (pulls lexer-builder)
 ```
 
-Run the guard for every package the branch's reference file names before writing code that imports it — a feature added mid-task (a nested lexer inside parser work, a `.pp3` generate step after prototyping) re-enters this table with its own row.
+**Step 2 — for each missing package, ask the user before installing.** Say what and why, e.g.: *"The parser branch needs `phplrt/parser-builder` as a dev dependency — it provides the `ParserBuilder` class for prototyping the grammar and won't ship to production. Install it?"* For `phplrt/compiler`, mention it pulls laminas-code + symfony/console + twig — the reason it must stay `--dev`. Only after the user agrees:
+
+```bash
+composer require phplrt/runtime             # the one runtime dependency
+composer require --dev phplrt/<describer>   # compiler / lexer-builder / parser-builder
+```
+
+Re-enter this check for every package a reference file names before writing code that imports it — a feature added mid-task (a nested lexer inside parser work, a `.pp3` generate step after prototyping) brings its own row of the table, and its own ask.
 
 ## Mental model
 

--- a/skills/phplrt/SKILL.md
+++ b/skills/phplrt/SKILL.md
@@ -19,7 +19,7 @@ phplrt splits in two:
 - **Runtime** (`phplrt/runtime` = `phplrt/lexer` + `phplrt/parser` + `phplrt/source`) — what a shipped parser needs, and *all* it needs. A shipped parser is a plain PHP class that `extends \Phplrt\Parser\Parser`.
 - **Build-time describers** that turn a grammar into that class: the `.pp3` language read by `phplrt/compiler`, and the in-PHP `phplrt/lexer-builder` + `phplrt/parser-builder`. **Every one of these is a dev dependency.** `phplrt/compiler` alone drags in `laminas/laminas-code`, `symfony/console`, and `twig` — none of which belong in production.
 
-**The anti-pattern (do not do this):** calling `new Compiler()->...->getParser()`, or `$builder->build()->toParser()`, at request time. It forces a describer into `require`, recompiles the whole grammar on every boot, and in a real deploy — where the compiler is `require-dev` and simply isn't installed — fatals with a "class not found". "Give me a parser from what I just built" is a dev-loop convenience, never a shipping architecture.
+**The anti-pattern (do not do this):** calling `(new Compiler())->...->getParser()`, or `$builder->build()->toParser()`, at request time. It forces a describer into `require`, recompiles the whole grammar on every boot, and in a real deploy — where the compiler is `require-dev` and simply isn't installed — fatals with a "class not found". "Give me a parser from what I just built" is a dev-loop convenience, never a shipping architecture.
 
 **The correct flow — generate once, commit the output, depend only on the runtime:**
 
@@ -39,7 +39,7 @@ $parser = new App\Parser\MyParser();
 $ast = $parser->parse(Phplrt\Source\StringSource::createFromString($input));
 ```
 
-The generated class inlines the whole lexer as one regex and every reducer as a real method you can step through — there is no hidden runtime compilation left. `new Compiler()->load(new FileSource('grammar.pp3'))->generate()->withClassName(...)->withNamespaceName(...)->save('src/MyParser.php')` is the same thing from PHP if you would rather generate from a build script than the CLI.
+The generated class inlines the whole lexer as one regex and every reducer as a real method you can step through — there is no hidden runtime compilation left. `(new Compiler())->load(new FileSource('grammar.pp3'))->generate()->withClassName(...)->withNamespaceName(...)->save('src/MyParser.php')` is the same thing from PHP if you would rather generate from a build script than the CLI. (Wrap the `new` in parens: phplrt 4 runs on PHP 8.1+, and the parenthesis-free `new Compiler()->load(...)` chain is 8.4-only syntax that fatals on 8.1–8.3.)
 
 **Corollary — don't fight the codegen.** If you compile a grammar into a `ParserBuilderResult` and then bolt a hand-written lexer onto it at runtime, or keep a static-cached `getParser()`, you have turned a code generator into a runtime interpreter — the same dead-weight trap, most of the code doing work `save()` would have done once. Put the hand-written lexer *inside* the grammar (`%lexer name -> { new App\MyLexer() }`, or a lexer state — see `reference/nested.md`) so one generated class is self-contained, then generate it. And reduce rules into **typed AST nodes**, not one generic catch-all node — a parser that returns a single `Node` type for everything threw away the structure that was the point of parsing.
 
@@ -56,7 +56,7 @@ Phplrt is split into components; each class lives in its own package. A "class n
 Resolve the PHP and composer binaries **once, in this preparatory phase**, and reuse the absolute paths everywhere — including inside subagents, which may not share the parent shell's `PATH` and would otherwise fail with `php: command not found`.
 
 ```bash
-PHP_BIN="$(command -v php || command -v php8.4 || command -v php8.3)"
+PHP_BIN="$(command -v php || command -v php8.4 || command -v php8.3 || command -v php8.2 || command -v php8.1)"  # phplrt 4 needs 8.1+
 COMPOSER="$(command -v composer || echo "$PHP_BIN $(command -v composer.phar)")"
 "$PHP_BIN" -v   # confirm it actually runs
 ```

--- a/skills/phplrt/reference/lexer.md
+++ b/skills/phplrt/reference/lexer.md
@@ -1,0 +1,71 @@
+# Lexer reference (Phplrt LexerBuilder)
+
+Plain reference reached from the `phplrt` skill. The full surface is at https://phplrt.org/llms.txt — this file keeps only decisions and traps.
+
+> Packages you need: see **Pre-flight** in `../SKILL.md` (lexer branch → `phplrt/lexer-builder` + `phplrt/source`).
+
+## Declare tokens
+
+```php
+use Phplrt\Lexer\Builder\LexerBuilder;
+
+$lexer = new LexerBuilder();
+$lexer->addPattern('[A-Za-z_]\w*', 'T_WORD');   // regex, token name
+$lexer->addValue('+', 'T_PLUS');                 // literal, safer than a regex
+$lexer->addPattern('\s+')->hide();               // skip, keep in stream off
+```
+
+- **Declaration order wins, not length.** The generated regex is a single PCRE alternation (`\G(?|pattern1|pattern2|...)`, one branch per token in the order added), and PCRE alternation is leftmost-first: the *first* pattern that matches at the current position wins, even if a later one would have matched more characters. Put a keyword or a multi-char pattern *before* the generic rule it would otherwise be swallowed by (a keyword before an identifier pattern that also matches it) — there is no length-based fallback to rescue a rule declared too late.
+- `addValue($lit, $name)` builds a literal pattern; prefer it for punctuation so you never debug an escaped regex.
+
+## PCRE modifiers
+
+```php
+use Phplrt\Lexer\Builder\Definition\RegexModifier;
+
+$lexer->disable(RegexModifier::DotAll);   // '.' stops matching newlines (line lexing)
+$lexer->enable(RegexModifier::Multiline); // '^'/'$' match line starts (usually default)
+$lexer->enable(RegexModifier::Caseless);  // case-insensitive tokens
+```
+
+- **DotAll is ON by default** — disable it for line-based formats or your `[^\n]+` will swallow the file.
+- A sub-lexer (nested) has its own modifier state; set it on the sub-lexer too.
+
+## Channels / hidden tokens
+
+```php
+$lexer->addPattern('\s+', 'T_WS')->hide();
+```
+
+- Hidden tokens are removed from the parser's token stream but **remain in an embedding's `children`** if a sub-lexer produced them. Skip them by name when walking children.
+- Use hiding for whitespace/comments you don't want as grammar tokens. Do not `hide()` tokens the grammar must reference.
+
+## Nested lexers (enter a sub-lexer)
+
+```php
+$lexer->addPattern('"', 'T_DQUOTE_OPEN')->enter('string');
+$string = $lexer->addLexer('string');
+$string->addPattern('[^"]+', 'T_STR_CHARS');
+$string->addPattern('"', 'T_DQUOTE_CLOSE')->exit();
+```
+
+- `->enter('name')` switches to the named sub-lexer at that token; `->exit()` returns to the parent.
+- The opening token becomes a `TokenEmbedding`; the parser references it and walks `$token->children`.
+- See `reference/nested.md` for the frontmatter / fenced-code recipe and how the `TokenEmbedding` is read.
+
+## Build
+
+```php
+use Phplrt\Lexer\Builder\Transformer\RuntimeLexerTransformer;
+use Phplrt\Source\StringSource;
+
+$lexerResult = $lexer->build();
+$runtimeLexer = (new RuntimeLexerTransformer())->transform($lexerResult);
+foreach ($runtimeLexer->lex(StringSource::createFromString($src)) as $tok) {
+    // $tok->name, $tok->value; embedded fragments are TokenEmbedding
+}
+```
+
+Hand `$lexerResult` and `$runtimeLexer` to `ParserBuilder` (see `reference/parser.md`): `$parser = $builder->build($lexerResult)->toParser($runtimeLexer);`.
+
+`build()` here is a **dev-time** step (it needs `phplrt/lexer-builder`). A standalone lexer you only use for tokenizing is usually a prototype; if it feeds a parser you ship, the whole thing gets generated into one runtime-only class — don't keep `build()` on the request path in production. See the SKILL's "Ship the runtime".

--- a/skills/phplrt/reference/nested.md
+++ b/skills/phplrt/reference/nested.md
@@ -1,0 +1,153 @@
+# Nested lexers reference (Phplrt embedded lexers)
+
+Plain reference reached from the `phplrt` skill. Full surface: https://phplrt.org/llms.txt. This file is the part not obvious from the API.
+
+> Packages you need: see **Pre-flight** in `../SKILL.md` (nested lexers need `phplrt/lexer-builder` + `phplrt/source`).
+
+## The mechanism
+
+```php
+$lexer = new LexerBuilder();
+$lexer->disable(RegexModifier::DotAll);
+
+// Opening token ENTERS a sub-lexer.
+$fm = $lexer->addPattern('\A---+[^\n]*\n?', 'T_FM_DELIM')->enter('frontmatter');
+
+$sub = $lexer->addLexer('frontmatter');
+$sub->addPattern('^---+[^\n]*\n?', 'T_FM_DELIM_CLOSE')->exit(); // EXIT back to parent
+$sub->addPattern('^[A-Za-z_][\w-]*:', 'T_FM_KEY');
+$sub->addPattern('[^\n]*\n?', 'T_FM_VALUE');
+```
+
+- `->enter('lang')` switches the active lexer to the named sub-lexer at that token; `->exit()` returns to the parent.
+- The **opening token becomes a `TokenEmbedding`**. The parser references `T_FM_DELIM` (by the `TokenDefinition` object) and reads the fragment from `$token->children`, never from inner token names.
+- Each child has `->name` and `->value`. Walk them in the reducer.
+
+## Read the embedding
+
+```php
+$frontmatter = $builder->addTokenReference($fm)   // the TokenDefinition from addPattern
+    ->setReducer(static function ($ctx, $token) use ($inline) {
+        $attrs = [];
+        $key = null;
+        foreach ($token->children as $child) {
+            switch ($child->name) {
+                case 'T_FM_KEY':
+                    $key = rtrim($child->value, ':');
+                    $attrs[$key] = '';
+                    break;
+                case 'T_FM_VALUE':
+                    if ($key !== null) { $attrs[$key] .= trim($child->value); }
+                    break;
+                case 'T_FM_DELIM_CLOSE':
+                    break 2;                        // stop at the closing line
+            }
+        }
+        return new Node('frontmatter', $attrs);
+    });
+```
+
+- Inside a sub-lexer, `^` matches the **start of each line** (multiline is default) — but `\A` in the parent matches only the file start, so the frontmatter opens only at the top.
+- Hidden tokens inside the sub-lexer (e.g. a comment) still appear in `$token->children`; skip them by name.
+
+## Fenced code block — same shape
+
+```php
+$code = $lexer->addPattern('^```[^\n]*\n?', 'T_FENCE')->enter('code');
+$sub  = $lexer->addLexer('code');
+$sub->addPattern('^```[^\n]*\n?', 'T_FENCE_CLOSE')->exit();
+$sub->addPattern('[^\n]*\n', 'T_CODE_LINE');
+
+$codeBlock = $builder->addTokenReference($code)
+    ->setReducer(static function ($ctx, $token) {
+        $src = '';
+        foreach ($token->children as $child) {
+            if ($child->name === 'T_FENCE_CLOSE') { break; }
+            $src .= $child->value;
+        }
+        return new Node('code_block', ['code' => $src]);
+    });
+```
+
+## When a regex sub-lexer isn't enough: a hand-written `LexerInterface`
+
+`enter()`/`addLexer()` above is still a *regex* sub-lexer — every token in it is a pattern
+declared up front. That falls apart the moment where a fragment ends depends on something only
+known at match time, not at declaration time: how far a list item or a blockquote is
+indented, for instance. Indentation is a column, and a lexer state is a fixed, named thing —
+there is no way to declare "the state for column 7" ahead of the input.
+
+For that, embed a real class instead of another regex sub-lexer:
+
+```php
+use Phplrt\Contracts\Lexer\LexerInterface;
+use Phplrt\Contracts\Source\ReadableInterface;
+use Phplrt\Lexer\Token\Token;
+use Phplrt\Lexer\Token\EndOfInputToken;
+use Phplrt\Contracts\Lexer\Channel;
+
+final class ListItemLexer implements LexerInterface
+{
+    public function __construct(private readonly int $id) {}
+
+    public function lex(ReadableInterface $source, int $offset = 0): iterable
+    {
+        // Read $source->content from $offset onward by hand: measure the
+        // marker's own column right here (it is only known now, from where
+        // this particular item happened to start), decide how many
+        // subsequent lines belong to this item by indentation, and yield
+        // whatever Token/EndOfInputToken objects the grammar expects.
+        // Nothing about this needs a pattern declared in advance.
+        yield new Token(id: $this->id, name: 'T_ITEM_BODY', channel: Channel::Default, value: '...', offset: $offset);
+        yield new EndOfInputToken($offset);
+    }
+}
+```
+
+```php
+$marker = $lexer->addPattern('^ {0,3}[-*+][ \t]+', 'T_LIST_MARKER')->enter('item');
+$lexer->addEmbeddedLexer('item', new ListItemLexer($someTokenId));
+```
+
+- `addEmbeddedLexer(string $name, LexerInterface $lexer)` registers any class implementing
+  `LexerInterface` as a named lexer state, the same slot `addLexer()` fills with a regex
+  sub-lexer — `enter('item')` reaches it exactly the same way.
+- The class gets the *whole* source and an offset; it decides for itself, in plain PHP, where
+  its own fragment ends and returns its tokens (ending in an `EndOfInputToken`) — there is no
+  regex layer underneath it at all.
+- This is how phplrt's own `.pp3` compiler reads a reducer's block of PHP code
+  (`PhpBlockLexer`, tracking brace depth by hand) and it is the only way to read Markdown's
+  own list/blockquote nesting or YAML-style indentation: measure the column right there in the
+  lexer, since no declared pattern can stand in for "however far *this* one happens to be
+  indented."
+- Recursion into a nested block's own structure (a list item that itself contains a list) is
+  not a lexer-state concept either — it is the reducer calling the *same* parser again on the
+  dedented fragment the embedded lexer handed it, tracking each line's true original offset
+  itself rather than a single before/after shift (a line loses a different number of bytes
+  than its neighbor once dedented, so one flat offset correction drifts as soon as there is
+  more than one line).
+
+### The same thing in a `.pp3` grammar (so it survives generation)
+
+`addEmbeddedLexer()` is the builder-API form. If you are shipping — i.e. generating a committed
+parser (see the SKILL's "Ship the runtime") — put the hand-written lexer *in the grammar*
+instead, so the one generated class stays self-contained. A token's action enters a state, and
+`%lexer` binds a class to that state:
+
+```
+%token T_LIST_MARKER  ^\h{0,3}[-*+]\h+  -> state(item)
+%lexer  item -> { new \App\ListItemLexer() }
+```
+
+This is exactly how phplrt's own pp3 grammar embeds `PhpBlockLexer`
+(`%lexer php -> { new \Phplrt\Compiler\Syntax\Common\PhpBlockLexer() }`). The generated parser
+calls `new \App\ListItemLexer()` in its constructor — that class needs only the runtime
+(`Phplrt\Contracts\Lexer\LexerInterface`), so nothing about the codegen path drags a builder or
+the compiler into production. A hand-written lexer bolted on *after* `getParser()` at runtime,
+by contrast, is the anti-pattern the SKILL warns about: it cannot be generated away.
+
+## Why this saves context
+
+One opening token carries the whole nested fragment; the grammar stays flat (it only names the opener) and the reducer holds the sub-format logic in one place. The outer parser never learns the inner language — that is the decomposition: each format lives behind its own `enter`, so an agent editing the code fence need not touch the frontmatter rule and vice versa.
+
+See `reference/lexer.md` for modifier/channel details and `reference/parser.md` for reducer value shapes.

--- a/skills/phplrt/reference/parser.md
+++ b/skills/phplrt/reference/parser.md
@@ -1,0 +1,107 @@
+# Parser reference (Phplrt ParserBuilder)
+
+Plain reference reached from the `phplrt` skill. Full surface: https://phplrt.org/llms.txt. Decisions and traps only.
+
+> Packages you need: see **Pre-flight** in `../SKILL.md` (parser branch → `phplrt/parser-builder` + `phplrt/source`).
+
+## Rule shapes
+
+```php
+$builder = new ParserBuilder();
+
+$word = $builder->addTokenReference('T_WORD')
+    ->setReducer(static fn($ctx, $tok) => $tok->value);
+
+$eq = $builder->addTokenReference('T_EQ');
+// every array element must be a RuleDefinition — a bare string throws a TypeError
+$pair = $builder->addConcatenation([$word, $eq, $word])
+    ->setReducer(static fn($ctx, $kids) => [$kids[0], $kids[2]]);
+
+$list = $builder->addRepetition($word, min: 1, name: 'List')
+    ->setReducer(static fn($ctx, $kids) => $kids);
+
+$alt = $builder->addAlternation([$pair, $word], 'Item');
+
+$builder->setInitialRule($alt);
+```
+
+- **`addTokenReference($def)`** takes a `TokenDefinition` (returned by `addPattern`) or a token name string.
+- **`addConcatenation(array $rules = [], ?string $name = null)`** — name is the **2nd** arg.
+- **`addAlternation(array $rules = [], ?string $name = null)`** — name is the **2nd** arg.
+- **`addRepetition($rule, $max = INF, $min = 0, ?string $name = null)`** — name is the **4th** arg; write `min: 1, name: 'X'`. `min: 0` lets the optimizer drop a nullable alternative — use `min: 1` to keep it.
+- **`addPredicate($rule, bool $isExpected = true, ?string $name = null)`** — lookahead: matches (or, with `isExpected: false`, refuses) the rule without consuming input or contributing to the result. The builder form of `.pp3`'s `&e` / `!e`; look ahead at a token reference, not a production — a refused production is still fully parsed before being thrown away.
+
+## Reducer value shape — the trap
+
+The reducer's second argument depends on the rule type:
+
+- **Concatenation / Repetition** (a `SequenceInterface`): a **flat array** of the children's reduced values, one slot per rule *reference* in the concatenation — there is no separate "discard this one's value but still require it positionally" mechanic in this API (unlike a `.pp3` grammar's `::T_X::`). Reference a token you only need to skip past (`$eq` above) without a reducer; its slot still lands in the array as the raw `TokenInterface` — just don't read that index. This is different from a `->hide()`d token (whitespace, say): that one is invisible to the *lexer's own stream*, so it never reaches the parser at all — no slot, no `[]`, nothing — rather than a token the grammar references but ignores.
+- **Alternation / Optional / Terminal**: a **single** value. For an absent optional it is `[]` (an empty array, not `null`) — the same "no slot at all" behavior an omitted optional child has inside a concatenation's own array.
+- A **kept terminal** (`addTokenReference`) with no reducer passes the raw `TokenInterface`; read `$token->value` / `$token->name` / `$token->children` (embedding) inside whichever reducer receives it.
+
+Rule of thumb: sequence → array, choice/terminal → scalar.
+
+## The flattening trap — a nested sequence's array merges into its parent's
+
+A subtler version of the same rule: if rule B is itself a Concatenation/Repetition and sits as
+*one reference* inside rule A's own Concatenation/Repetition, B's reduced array does not
+arrive as one element of A's array — it is spread into it, flattened one level, so A can no
+longer tell where B's own children ended and A's next child began.
+
+```php
+$pair = $builder->addConcatenation([$word, $word])           // returns e.g. ['a', 'b']
+    ->setReducer(static fn($ctx, $kids) => $kids);             // a bare array — will flatten
+
+$line = $builder->addConcatenation([$pair, $word])
+    ->setReducer(static function ($ctx, $kids) {
+        // $kids is ['a', 'b', 'c'] here, NOT [['a', 'b'], 'c'] — $pair's own
+        // array merged straight into $line's, indistinguishable from a
+        // $line that matched three plain words directly.
+        return $kids;
+    });
+```
+
+Fix it by making the nested rule's own reducer return something that is *not* a bare array —
+an object (even a single-property one), or a scalar; only an array gets flattened this way:
+
+```php
+$pair = $builder->addConcatenation([$word, $word])
+    ->setReducer(static fn($ctx, $kids) => (object) ['pair' => $kids]); // now it survives intact
+```
+
+This only shows up once a grammar nests two levels deep, so it is easy to write a rule that
+works fine in isolation and only breaks when something else starts referencing it.
+
+## Nested inline parser (markup inside a block)
+
+When a block's text carries its own markup (`**bold**`, `` `code` ``), build a second `ParserBuilder` once (static-cache it) and call it from the outer reducer:
+
+```php
+$inline = $this->inlineParser(); // builds a LexerBuilder+ParserBuilder for `**..**` etc.
+$block = $builder->addRepetition($textToken, min: 1, name: 'Paragraph')
+    ->setReducer(static fn($ctx, $kids) => $inline->parse(
+        StringSource::createFromString(implode("\n", $kids))
+    ));
+```
+
+Keep the inline lexer free of `.`/`\n` traps: match newlines with an explicit `\r?\n` token, or `DotAll` will make `.` eat them and `T_ANY` will not match a line break.
+
+## Build and run (dev loop) — then generate to ship
+
+`build()->toParser()` builds the parser in-process. That is the prototyping loop; **it is not what you ship** — leaving it on the hot path keeps `phplrt/parser-builder` in `require` and rebuilds the grammar on every call. Once the grammar is settled, express it as `.pp3` and generate a committed parser class that needs only the runtime (see the SKILL's "Ship the runtime").
+
+```php
+use Phplrt\Lexer\Builder\Transformer\RuntimeLexerTransformer;
+use Phplrt\Source\StringSource;
+
+$lexerResult = $lexer->build();
+$runtimeLexer = (new RuntimeLexerTransformer())->transform($lexerResult);
+$parser = $builder->build($lexerResult)->toParser($runtimeLexer);
+
+$tree = $parser->parse(StringSource::createFromString($src));
+```
+
+- Pass the **same** `$lexerResult` to `build()` and the **transformed** lexer to `toParser()`.
+- Wrap input in `StringSource::createFromString($src)` (or `FileSource::createFromPathname($path)`).
+- Frontmatter / fenced code / strings belong in a nested lexer — see `reference/nested.md`.
+- **Reduce to typed AST nodes**, not one generic node for everything — a tree that collapses every rule into a single `Node` type has thrown away the structure parsing existed to recover.

--- a/skills/phplrt/reference/pp3.md
+++ b/skills/phplrt/reference/pp3.md
@@ -1,0 +1,62 @@
+# PP3 grammar reference (the shipping path's own language)
+
+Plain reference reached from the `phplrt` skill. Full syntax: https://phplrt.org/llms.txt (PP3 Grammar Syntax). This file keeps the decisions and traps.
+
+> Needs `phplrt/compiler` (dev-only — see **Pre-flight** in `../SKILL.md`). Verify with `vendor/bin/phplrt check`, generate with `vendor/bin/phplrt compile` (see the SKILL's "Definition of done").
+
+## Skeleton
+
+```pp3
+%skip  T_WHITESPACE  \s++
+%token T_NUMBER      \d++
+%token T_PLUS        \+
+
+%pragma root Sum
+
+Sum -> { return \array_sum($children); }
+  : Number() (::T_PLUS:: Number())*
+  ;
+
+Number -> { return (int) $children->value; }
+  : <T_NUMBER>
+  ;
+```
+
+- Naming convention (unenforced, universal): tokens `T_SCREAMING_CASE`, rules `PascalCase`, fragments `SCREAMING_CASE` without the `T_`.
+- **Always set `%pragma root`.** The default is "first rule declared", which silently changes when an `%include` lands above it — the optimizer then drops everything unreachable from the wrong root. `check -v` exposes it: `Rules: Loaded: 7 / After: 1` means the root is wrong, not that the optimizer did well.
+
+## Tokens — the traps
+
+- **A declaration is one line, and the pattern cannot contain a literal space** — whitespace is what separates the parts. Write `\x20` or `\s`.
+- **Order wins, not length** (the same rule as the builders): `%token T_POW \*\*` before `%token T_STAR \*`; keywords before the `T_NAME` that would swallow them.
+- `%skip T_WS \s++` is shorthand for `-> channel(Hidden)`: the token is still recognized (offsets stay correct) but never reaches the parser.
+- `%fragment NAME re` names a pattern piece; `(?&NAME)` writes it into a token. A fragment is no token — no state, no action — and its declaration order does not matter (resolved after the whole grammar is read).
+
+## Rules
+
+- `<T_X>` reads a token and **keeps** it in the result; `::T_X::` reads it and **discards** it. Keep what carries information, discard the punctuation that only holds syntax together.
+- `Rule()` — the parentheses are what mark a rule reference; the rule may be declared later or in another file.
+- Inline tokens: `"+"` is literal text (nothing inside is special), `/re/` is a pattern. An inline token is always discarded; declare a real token for anything used more than twice so error messages can name it. A lone slash is `/\//` — bare `//` opens a comment.
+- Quantifiers after any token, rule, or group: `? * + {3} {2,5} {2,} {,5}`.
+- Predicates look ahead without consuming: `&e` goes on only if `e` matches next, `!e` only if it does not; nothing lands in the tree. `Variable : <T_NAME> !::T_LP:: ;` reads a name that is not a call — and leaves the `(` for whoever wants it. Look ahead at a token, not a rule: `!Expression()` really parses a whole expression just to throw it away.
+
+## PEG semantics — grammar-authoring traps
+
+- **Choice is ordered.** `Rule : "a" | "ab" ;` never reads `ab` — the first alternative that matches wins and the parser does not go back for a longer one. Longer alternative first.
+- **Left recursion is refused at compile time.** `Expr : Expr() ::T_PLUS:: Number() ;` never terminates; the standard translation is a repetition: `Expr : Number() (::T_PLUS:: Number())* ;`.
+- **The whole input must be consumed.** Trailing junk is a syntax error, not a stopping point.
+
+## Reducers
+
+`-> { ... }` sits between the rule name and the colon; the block returns the node. `$children` is the important variable: an **array** for a sequence rule (concatenation/repetition), a **single value** for anything else — and nested arrays flatten into the parent, so a rule that should produce a group must return an object, never a bare array (the same trap `reference/parser.md` spells out for the builder API). Other variables — `$ctx`, `$offset`/`$begin`, `$end`, `$length`, `$source`, `$content`, `$rule` — are expanded by the compiler only if used, so they cost nothing.
+
+Class names inside reducers: pass `--use "App\Ast\Node"` to `compile` so the grammar can write `new Node(...)` instead of the FQCN.
+
+## States and embedded lexers
+
+- `%token string:T_TEXT [^"]++` declares a token in state `string`; the actions `-> state(string)` and `-> exit()` move the reading in and out. `*:T_X` adds a token to every state (tried after the state's own tokens).
+- `%lexer name -> { new \App\MyLexer() }` binds a hand-written `LexerInterface` to a state. The body is an **expression** — no `return`, no semicolon. Such a lexer decides where its fragment ends by itself, so it needs no `exit()` token. See `reference/nested.md`.
+
+## %include
+
+`%include grammar/lexemes` — the path is relative to the including file, the extension may be omitted, and a file included from several places is read once. Declarations land exactly where the `%include` stands — which is how the default root goes wrong; `%pragma root` again.

--- a/skills/phplrt/reference/pp3.md
+++ b/skills/phplrt/reference/pp3.md
@@ -52,6 +52,20 @@ Number -> { return (int) $children->value; }
 
 Class names inside reducers: pass `--use "App\Ast\Node"` to `compile` so the grammar can write `new Node(...)` instead of the FQCN.
 
+## Custom error messages — `@error`
+
+`@error("message")` replaces the default `Syntax error, unexpected ...` when the thing it is written on fails to match. It rides along into the generated parser (compiled into its message table), so it works in the shipped runtime — no compiler needed at parse time.
+
+```pp3
+Root : ::T_OPEN:: Pair() @error("a pair of names is expected") ::T_CLOSE:: ;
+Pair @error("write it as name, name") : <T_NAME> ::T_COMMA:: <T_NAME> ;
+```
+
+- Write it **after** the element it annotates — a token, a `Rule()` reference, a group, or a quantified thing (`Number()* @error(...)`) — or after the rule's own name, before the `:` and before any `-> { reducer }`. On a predicate it annotates the lookahead: `&<T_NAME> @error("a name is expected")`.
+- **The innermost / furthest failure wins.** An `@error` on an outer rule does not mask a more specific one deeper in, and a plain syntax error that got *further* into the input still beats a shallower `@error` — the message reports the real failure point, same "furthest position reached" rule as `reference/parser.md` describes. So an `@error` fires only when its element is genuinely where parsing stalled.
+- Placeholders, filled from the token parsing stopped on: `{name}` (token name), `{line}`, `{column}`, `{expected}` (shortened token list), `{expected_list}` (full list). A literal brace is doubled: `{{name}}` → `{name}`.
+- Compile-time checks: exactly one non-empty argument, and not two `@error` on the same rule — either is a `CompilationFailedException` / `UnsupportedAnnotationException` at `check`.
+
 ## States and embedded lexers
 
 - `%token string:T_TEXT [^"]++` declares a token in state `string`; the actions `-> state(string)` and `-> exit()` move the reading in and out. `*:T_X` adds a token to every state (tried after the state's own tokens).


### PR DESCRIPTION
### What was a problem?

Agents building parsers with phplrt keep making the same expensive mistake: wiring `LexerBuilder`/`ParserBuilder` (or `Compiler::getParser()`) at request time, which ships dev-only describers to production and recompiles the grammar on every boot. The API surface alone also doesn't warn about the traps that cost the most debugging time: token declaration order, reducer value shapes, array flattening into the parent rule, PEG semantics (ordered choice, no left recursion).

### How this PR fixes the problem?

Adds a `skills/phplrt` agent skill that teaches the correct flow — describe a grammar in `.pp3`, generate a committed parser class, depend only on `phplrt/runtime` — with per-branch reference files: `lexer.md`, `parser.md`, `pp3.md` (the grammar language itself), `nested.md` (embedded lexers). A "Definition of done" section gives four exit-code acceptance criteria (grammar `check`, staleness diff of the generated parser, builder-free production code, a test constructing the committed class), matching the Automation and CI recipe from the docs.

`composer.json` gets an `extra.skills.source` entry pointing the testo/testo skill auto-sync at the `skills` directory, and `.claude` joins `.gitignore` next to `.agents`.

### Additional Comments (if any)

Every API claim in the skill (signatures, defaults, CLI options, pp3 syntax) is verified against the sources in this repository and https://phplrt.org/llms-full.txt.
