### PR TITLE
Fix non-kept token in rules

### DIFF
--- a/libs/components/compiler/src/Node/Declaration/RuleDeclaration.php
+++ b/libs/components/compiler/src/Node/Declaration/RuleDeclaration.php
@@ -36,8 +36,8 @@ final class RuleDeclaration extends Declaration
          */
         public readonly ?Reducer $reducer = null,
         /**
-         * Contains {@see true} in case of the rule is kept in the syntax tree
-         * even when it recognizes a single child
+         * Contains {@see true} in case of the name of the rule is kept on the
+         * compiled parser, so the analysis may be started at the rule
          */
         public readonly bool $isKept = false,
         /**

--- a/libs/components/compiler/src/Syntax/Common/PPLoader.php
+++ b/libs/components/compiler/src/Syntax/Common/PPLoader.php
@@ -39,6 +39,7 @@ use Phplrt\Lexer\Builder\LexerBuilder;
 use Phplrt\Parser\Builder\Definition\Reducer\PhpCodeReducer;
 use Phplrt\Parser\Builder\Definition\RuleDefinition;
 use Phplrt\Parser\Builder\Definition\RuleReference as RuleReferenceDefinition;
+use Phplrt\Parser\Builder\Definition\TerminalRuleDefinition;
 use Phplrt\Parser\Builder\ParserBuilder;
 use Phplrt\Parser\Exception\MessagePlaceholder;
 
@@ -325,15 +326,17 @@ abstract class PPLoader implements SyntaxLoaderInterface
     /**
      * Returns the rule the declaration is known by.
      *
-     * A reference stands for another rule instead of being one and never
-     * reaches the compiled grammar, so a rule written of nothing but a
-     * reference is wrapped into a production to be named at all.
-     *
      * @param non-empty-string $name
      */
     private function nameRule(RuleDefinition $body, string $name, ParserBuilder $parser): RuleDefinition
     {
-        if ($body instanceof RuleReferenceDefinition) {
+        // Generate virtual concat production for:
+        // - Any production reference
+        // - Non-kept token definition
+        $hasVirtualConcatenation = $body instanceof RuleReferenceDefinition
+            || ($body instanceof TerminalRuleDefinition && !$body->isKept);
+
+        if ($hasVirtualConcatenation) {
             return $parser->addConcatenation([$body], $name);
         }
 

--- a/libs/components/compiler/src/Syntax/Common/PPLoader.php
+++ b/libs/components/compiler/src/Syntax/Common/PPLoader.php
@@ -75,14 +75,6 @@ abstract class PPLoader implements SyntaxLoaderInterface
     private const ANNOTATION_ERROR = 'error';
 
     /**
-     * The body of the reducer standing for the "#" marker, which builds no
-     * node of its own.
-     *
-     * @var non-empty-string
-     */
-    private const REDUCER_KEEP = 'return $children;';
-
-    /**
      * The variables a reducer may be written of, along with what each of them
      * stands for.
      *
@@ -391,13 +383,7 @@ abstract class PPLoader implements SyntaxLoaderInterface
             return $reducer->code;
         }
 
-        /**
-         * A rule declared with the "#" prefix is kept in the tree even when it
-         * recognizes a single child, and a rule building a node of its own is
-         * exactly what is kept, so the marker is honoured by a reducer handing
-         * the children over as they are.
-         */
-        return $declaration->isKept ? self::REDUCER_KEEP : '';
+        return '';
     }
 
     /**

--- a/libs/components/compiler/tests/PP2LoaderTest.php
+++ b/libs/components/compiler/tests/PP2LoaderTest.php
@@ -159,14 +159,11 @@ final class PP2LoaderTest extends TestCase
         $this->load('%pragma check_tokens false');
     }
 
-    public function testKeptRuleBuildsANodeOfItsOwn(): void
+    public function testKeptRuleBuildsNoNodeOfItsOwn(): void
     {
         $this->load('#A : <T_A> ;');
 
-        $reducer = $this->parser->initial?->reducer;
-
-        Assert::instanceOf($reducer, PhpCodeReducer::class);
-        Assert::same($reducer->code, 'return $children;');
+        Assert::null($this->parser->initial?->reducer);
     }
 
     public function testCodeReducer(): void

--- a/libs/components/compiler/tests/PP2LoaderTest.php
+++ b/libs/components/compiler/tests/PP2LoaderTest.php
@@ -12,6 +12,7 @@ use Phplrt\Lexer\Builder\Definition\RegexTokenDefinition;
 use Phplrt\Lexer\Builder\Definition\TokenDefinition;
 use Phplrt\Lexer\Builder\Definition\TransitionType;
 use Phplrt\Lexer\Builder\LexerBuilder;
+use Phplrt\Parser\Builder\Definition\ConcatenationRuleDefinition;
 use Phplrt\Parser\Builder\Definition\Reducer\PhpCodeReducer;
 use Phplrt\Parser\Builder\Definition\RuleDefinition;
 use Phplrt\Parser\Builder\Definition\RuleReference;
@@ -115,10 +116,25 @@ final class PP2LoaderTest extends TestCase
     {
         $this->load('A : "\+" ;');
 
+        [$terminal] = $this->parser->initial?->children ?? [];
+
+        Assert::instanceOf($terminal, TerminalRuleDefinition::class);
+        Assert::false($terminal->isKept);
+    }
+
+    public function testRuleOfASkippedTokenIsAProduction(): void
+    {
+        $this->load('A : ::T_A:: ;');
+
         $rule = $this->parser->initial;
 
-        Assert::instanceOf($rule, TerminalRuleDefinition::class);
-        Assert::false($rule->isKept);
+        Assert::instanceOf($rule, ConcatenationRuleDefinition::class);
+        Assert::same($rule->name, 'A');
+
+        [$terminal] = $rule->children;
+
+        Assert::instanceOf($terminal, TerminalRuleDefinition::class);
+        Assert::false($terminal->isKept);
     }
 
     public function testTokenReferenceIsKept(): void

--- a/libs/components/compiler/tests/PP3LoaderTest.php
+++ b/libs/components/compiler/tests/PP3LoaderTest.php
@@ -80,6 +80,36 @@ final class PP3LoaderTest extends TestCase
         $this->load("%token T_A a\nA -> \\App\\Node : <T_A> ;");
     }
 
+    public function testReducerOfASkippedTokenIsCalled(): void
+    {
+        $parser = $this->compile(<<<'PP3'
+            %token T_A a
+
+            A -> { return 42; }
+              : ::T_A::
+              ;
+            PP3);
+
+        Assert::same($parser->parse(StringSource::createFromString('a')), 42);
+    }
+
+    public function testReducerOfANestedSkippedTokenIsCalled(): void
+    {
+        $parser = $this->compile(<<<'PP3'
+            %token T_A a
+
+            A -> { return $children; }
+              : B()
+              ;
+
+            B -> { return 42; }
+              : ::T_A::
+              ;
+            PP3);
+
+        Assert::same($parser->parse(StringSource::createFromString('a')), [42]);
+    }
+
     public function testExpectedPredicate(): void
     {
         $parser = $this->compile(<<<'PP3'

--- a/libs/components/parser/src/Parser.php
+++ b/libs/components/parser/src/Parser.php
@@ -65,11 +65,6 @@ class Parser implements ParserInterface
      * @param ChoicePredictionTableType $choicePrediction the alternatives
      *        of every alternation worth trying, indexed by the token the
      *        reading is at
-     * @param ExpectationsTableType $expectations the way an error has to
-     *        name each token: by its name, or by what an anonymous one is
-     *        recognized by
-     * @param MessageTableType $messages the message describing the failure of
-     *        a rule, indexed by the rule identifiers
      */
     public function __construct(
         private readonly LexerInterface $lexer,
@@ -79,7 +74,19 @@ class Parser implements ParserInterface
         array $lookahead = [],
         array $kept = [],
         array $choicePrediction = [],
+        /**
+         * The way an error has to name each token: by its name, or by what an
+         * anonymous one is recognized by
+         *
+         * @var ExpectationsTableType
+         */
         private readonly array $expectations = [],
+        /**
+         * The message describing the failure of a rule, indexed by the
+         * rule identifiers
+         *
+         * @var MessageTableType
+         */
         private readonly array $messages = [],
     ) {
         $this->table = new GrammarTable(


### PR DESCRIPTION
### What was a problem?

```
ExampleRule -> { return 42; } // define reducer
  : ::T_EXAMPLE::  // DO NOT keep the token
```

The compiler marked such rule as unused and "collapsed" it (optimized it)

### How this PR fixes the problem?

If a rule contains a non-kept token, an empty concat is generated for it.

Further optimizer steps will automatically check for unnecessary concats without a reducer and remove them. If a reducer is present, the rule will be preserved.