### PR TITLE
Add adjacency operator support

### DIFF
--- a/libs/components/compiler/resources/grammar/pp3/lexemes.pp3
+++ b/libs/components/compiler/resources/grammar/pp3/lexemes.pp3
@@ -106,6 +106,8 @@
 %token T_AMPERSAND        &
 %token T_EXCLAMATION      !
 
+%token T_TILDE            ~
+
 /**
  * A token a rule declares by the expression recognizing it. The comments are
  * declared before it, so a slash still opens a comment where it always did.

--- a/libs/components/compiler/resources/grammar/pp3/statements.pp3
+++ b/libs/components/compiler/resources/grammar/pp3/statements.pp3
@@ -81,7 +81,22 @@ Concatenation -> {
         length: \max(0, $last->offset + $last->length - $statements[0]->offset),
     );
 }
-  : Element()+
+  : (Adjacency() | Element())+
+  ;
+
+/**
+ * An "adjacency" sequence, like:
+ * - <T_NAME> ~ ::T_NS_SEPARATOR:: ~ <T_NAME>
+ */
+Adjacency -> {
+    \assert($children instanceof \Phplrt\Lexer\Token\Token);
+
+    return new \Phplrt\Compiler\Node\Statement\Adjacency(
+        offset: $children->offset,
+        length: $children->size,
+    );
+}
+  : <T_TILDE>
   ;
 
 /**

--- a/libs/components/compiler/src/Generator/PhpCodePrinter.php
+++ b/libs/components/compiler/src/Generator/PhpCodePrinter.php
@@ -14,6 +14,7 @@ use Phplrt\Parser\Builder\Definition\Reducer\CallableReducer;
 use Phplrt\Parser\Builder\Definition\Reducer\PhpCodeReducer;
 use Phplrt\Parser\Builder\Definition\Reducer\ReducerInterface;
 use Phplrt\Parser\Context;
+use Phplrt\Parser\Grammar\Adjacency;
 use Phplrt\Parser\Grammar\Alternation;
 use Phplrt\Parser\Grammar\Concatenation;
 use Phplrt\Parser\Grammar\Lexeme;
@@ -208,6 +209,9 @@ final class PhpCodePrinter
             ]),
             $rule instanceof Predicate => self::printExpression(Predicate::class, [
                 (string) $rule->ruleId,
+                self::printBool($rule->isExpected),
+            ]),
+            $rule instanceof Adjacency => self::printExpression(Adjacency::class, [
                 self::printBool($rule->isExpected),
             ]),
             $rule instanceof Lexeme => self::printExpression(Lexeme::class, [

--- a/libs/components/compiler/src/Node/Statement/Adjacency.php
+++ b/libs/components/compiler/src/Node/Statement/Adjacency.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phplrt\Compiler\Node\Statement;
+
+/**
+ * Requires the token behind it and the token ahead of it to be written one
+ * right after another.
+ *
+ * @readonly
+ */
+final class Adjacency extends Statement
+{
+    /**
+     * @param int<0, max> $offset
+     * @param int<0, max> $length
+     */
+    public function __construct(
+        /**
+         * Contains {@see true} in case of the rule goes on when the tokens are
+         * written with nothing in between, or {@see false} in case of the rule
+         * goes on when they are not.
+         */
+        public readonly bool $isExpected = true,
+        int $offset = 0,
+        int $length = 0,
+    ) {
+        parent::__construct(
+            offset: $offset,
+            length: $length,
+        );
+    }
+}

--- a/libs/components/compiler/src/Node/Statement/Statement.php
+++ b/libs/components/compiler/src/Node/Statement/Statement.php
@@ -9,7 +9,7 @@ use Phplrt\Compiler\Node\Node;
 /**
  * A part of what a rule of the parser recognizes.
  *
- * @phpstan-sealed Alternation|Annotated|Concatenation|InlinePattern|InlineValue|Predicate|Repetition|RuleReference|TokenReference
+ * @phpstan-sealed Adjacency|Alternation|Annotated|Concatenation|InlinePattern|InlineValue|Predicate|Repetition|RuleReference|TokenReference
  *
  * @readonly
  */

--- a/libs/components/compiler/src/Syntax/Common/PPLoader.php
+++ b/libs/components/compiler/src/Syntax/Common/PPLoader.php
@@ -18,6 +18,7 @@ use Phplrt\Compiler\Node\Declaration\RuleDeclaration;
 use Phplrt\Compiler\Node\Declaration\TokenDeclaration;
 use Phplrt\Compiler\Node\Reducer\ClassReducer;
 use Phplrt\Compiler\Node\Reducer\CodeReducer;
+use Phplrt\Compiler\Node\Statement\Adjacency;
 use Phplrt\Compiler\Node\Statement\Alternation;
 use Phplrt\Compiler\Node\Statement\Annotated;
 use Phplrt\Compiler\Node\Statement\Concatenation;
@@ -468,6 +469,9 @@ abstract class PPLoader implements SyntaxLoaderInterface
             $statement instanceof Repetition => $this->createRepetition($statement, $source, $parser, $lexer),
             $statement instanceof Predicate => $parser->addPredicate(
                 rule: $this->loadStatement($statement->statement, $source, $parser, $lexer),
+                isExpected: $statement->isExpected,
+            ),
+            $statement instanceof Adjacency => $parser->addAdjacency(
                 isExpected: $statement->isExpected,
             ),
             $statement instanceof Annotated => $this->createAnnotated($statement, $source, $parser, $lexer),

--- a/libs/components/compiler/src/Syntax/PP3/PP3Parser.php
+++ b/libs/components/compiler/src/Syntax/PP3/PP3Parser.php
@@ -92,7 +92,9 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
     /** @var int */
     public const T_EXCLAMATION = 29;
     /** @var int */
-    public const T_REGEX = 30;
+    public const T_TILDE = 30;
+    /** @var int */
+    public const T_REGEX = 31;
 
     /**
      * @var \Phplrt\Contracts\Parser\ParserInterface<TResult>
@@ -124,12 +126,12 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
         );
 
         $this->lexer = new \Phplrt\Lexer\Lexer(
-            pattern: '/\\G(?|(?:(?:\\s++)(*MARK:0))|(?:(?:\\/\\/[^\\r\\n]*+)(*MARK:1))|(?:(?:\\/\\*(.*?)\\*\\/)(*MARK:2))|(?:(?:%pragma\\h++([a-zA-Z_][a-zA-Z0-9_.]*+)\\h++(\\S++))(*MARK:3))|(?:(?:%include\\h++(\\S++))(*MARK:4))|(?:(?:->\\s*+(?=\\{))(*MARK:5))|(?:(?:@([a-zA-Z_][a-zA-Z0-9_]*+))(*MARK:6))|(?:(?:;)(*MARK:7))|(?:(?:\\|)(*MARK:8))|(?:(?:\\()(*MARK:9))|(?:(?:\\))(*MARK:10))|(?:(?:<)(*MARK:11))|(?:(?:>)(*MARK:12))|(?:(?:\\?)(*MARK:13))|(?:(?:\\+)(*MARK:14))|(?:(?:\\*)(*MARK:15))|(?:(?:\\{)(*MARK:16))|(?:(?:\\})(*MARK:17))|(?:(?:,)(*MARK:18))|(?:(?:\\d++)(*MARK:19))|(?:(?:"[^"\\\\]*+(?:\\\\.[^"\\\\]*+)*+")(*MARK:20))|(?:(?:\\\\?+[a-zA-Z_][a-zA-Z0-9_]*+(?:\\\\[a-zA-Z_][a-zA-Z0-9_]*+)*+)(*MARK:21))|(?:(?:%token(?=\\h))(*MARK:22))|(?:(?:%skip(?=\\h))(*MARK:23))|(?:(?:%fragment(?=\\h))(*MARK:24))|(?:(?:%lexer\\h++([a-zA-Z_][a-zA-Z0-9_]*+))(*MARK:25))|(?:(?:::)(*MARK:26))|(?:(?::)(*MARK:27))|(?:(?:&)(*MARK:28))|(?:(?:!)(*MARK:29))|(?:(?:\\/([^\\/\\\\]*+(?:\\\\.[^\\/\\\\]*+)*+)\\/)(*MARK:30))|(?:(?:[^\\s]++)(*MARK:31)))/Ssum',
+            pattern: '/\\G(?|(?:(?:\\s++)(*MARK:0))|(?:(?:\\/\\/[^\\r\\n]*+)(*MARK:1))|(?:(?:\\/\\*(.*?)\\*\\/)(*MARK:2))|(?:(?:%pragma\\h++([a-zA-Z_][a-zA-Z0-9_.]*+)\\h++(\\S++))(*MARK:3))|(?:(?:%include\\h++(\\S++))(*MARK:4))|(?:(?:->\\s*+(?=\\{))(*MARK:5))|(?:(?:@([a-zA-Z_][a-zA-Z0-9_]*+))(*MARK:6))|(?:(?:;)(*MARK:7))|(?:(?:\\|)(*MARK:8))|(?:(?:\\()(*MARK:9))|(?:(?:\\))(*MARK:10))|(?:(?:<)(*MARK:11))|(?:(?:>)(*MARK:12))|(?:(?:\\?)(*MARK:13))|(?:(?:\\+)(*MARK:14))|(?:(?:\\*)(*MARK:15))|(?:(?:\\{)(*MARK:16))|(?:(?:\\})(*MARK:17))|(?:(?:,)(*MARK:18))|(?:(?:\\d++)(*MARK:19))|(?:(?:"[^"\\\\]*+(?:\\\\.[^"\\\\]*+)*+")(*MARK:20))|(?:(?:\\\\?+[a-zA-Z_][a-zA-Z0-9_]*+(?:\\\\[a-zA-Z_][a-zA-Z0-9_]*+)*+)(*MARK:21))|(?:(?:%token(?=\\h))(*MARK:22))|(?:(?:%skip(?=\\h))(*MARK:23))|(?:(?:%fragment(?=\\h))(*MARK:24))|(?:(?:%lexer\\h++([a-zA-Z_][a-zA-Z0-9_]*+))(*MARK:25))|(?:(?:::)(*MARK:26))|(?:(?::)(*MARK:27))|(?:(?:&)(*MARK:28))|(?:(?:!)(*MARK:29))|(?:(?:~)(*MARK:30))|(?:(?:\\/([^\\/\\\\]*+(?:\\\\.[^\\/\\\\]*+)*+)\\/)(*MARK:31))|(?:(?:[^\\s]++)(*MARK:32)))/Ssum',
             channels: [
                 'Hidden',
                 'Hidden',
                 'Hidden',
-                31 => 'Unknown',
+                32 => 'Unknown',
             ],
             names: [
                 'T_WHITESPACE',
@@ -162,6 +164,7 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
                 'T_COLON',
                 'T_AMPERSAND',
                 'T_EXCLAMATION',
+                'T_TILDE',
                 'T_REGEX',
             ],
             transitions: [
@@ -176,7 +179,7 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
                 1,
                 6 => 1,
                 25 => 1,
-                30 => 1,
+                31 => 1,
             ],
         );
 
@@ -194,7 +197,7 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
                 new \Phplrt\Parser\Grammar\Concatenation([9, 10]),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_LEXER, true),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_PHP, true),
-                new \Phplrt\Parser\Grammar\Concatenation([12, 13, 25, 26, 27, 63]),
+                new \Phplrt\Parser\Grammar\Concatenation([12, 13, 25, 26, 27, 65]),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_NAME, true),
                 new \Phplrt\Parser\Grammar\Optional(14),
                 new \Phplrt\Parser\Grammar\Repetition(15, 1, \INF),
@@ -210,43 +213,45 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_PARENTHESIS_CLOSE, false),
                 new \Phplrt\Parser\Grammar\Optional(10),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_COLON, false),
-                new \Phplrt\Parser\Grammar\Concatenation([28, 60]),
+                new \Phplrt\Parser\Grammar\Concatenation([28, 62]),
                 new \Phplrt\Parser\Grammar\Repetition(29, 1, \INF),
-                new \Phplrt\Parser\Grammar\Concatenation([30, 34, 13]),
-                new \Phplrt\Parser\Grammar\Optional(31),
-                new \Phplrt\Parser\Grammar\Alternation([32, 33]),
+                new \Phplrt\Parser\Grammar\Alternation([30, 31]),
+                new \Phplrt\Parser\Grammar\Lexeme(self::T_TILDE, true),
+                new \Phplrt\Parser\Grammar\Concatenation([32, 36, 13]),
+                new \Phplrt\Parser\Grammar\Optional(33),
+                new \Phplrt\Parser\Grammar\Alternation([34, 35]),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_AMPERSAND, true),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_EXCLAMATION, true),
-                new \Phplrt\Parser\Grammar\Concatenation([35, 46]),
-                new \Phplrt\Parser\Grammar\Alternation([36, 37, 40, 42, 43]),
+                new \Phplrt\Parser\Grammar\Concatenation([37, 48]),
+                new \Phplrt\Parser\Grammar\Alternation([38, 39, 42, 44, 45]),
                 new \Phplrt\Parser\Grammar\Concatenation([17, 27, 24]),
-                new \Phplrt\Parser\Grammar\Concatenation([38, 12, 39]),
+                new \Phplrt\Parser\Grammar\Concatenation([40, 12, 41]),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_ANGLE_OPEN, false),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_ANGLE_CLOSE, false),
-                new \Phplrt\Parser\Grammar\Concatenation([41, 12, 41]),
+                new \Phplrt\Parser\Grammar\Concatenation([43, 12, 43]),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_DOUBLE_COLON, false),
                 new \Phplrt\Parser\Grammar\Concatenation([12, 17, 24]),
-                new \Phplrt\Parser\Grammar\Alternation([44, 45]),
+                new \Phplrt\Parser\Grammar\Alternation([46, 47]),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_STRING, true),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_REGEX, true),
-                new \Phplrt\Parser\Grammar\Optional(47),
-                new \Phplrt\Parser\Grammar\Alternation([48, 49, 50, 51]),
+                new \Phplrt\Parser\Grammar\Optional(49),
+                new \Phplrt\Parser\Grammar\Alternation([50, 51, 52, 53]),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_QUESTION_MARK, true),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_PLUS, true),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_ASTERISK, true),
-                new \Phplrt\Parser\Grammar\Concatenation([52, 53, 59]),
+                new \Phplrt\Parser\Grammar\Concatenation([54, 55, 61]),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_BRACE_OPEN, false),
-                new \Phplrt\Parser\Grammar\Alternation([54, 56, 57, 58]),
-                new \Phplrt\Parser\Grammar\Concatenation([55, 23, 55]),
+                new \Phplrt\Parser\Grammar\Alternation([56, 58, 59, 60]),
+                new \Phplrt\Parser\Grammar\Concatenation([57, 23, 57]),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_INT, true),
-                new \Phplrt\Parser\Grammar\Concatenation([55, 23]),
-                new \Phplrt\Parser\Grammar\Concatenation([23, 55]),
+                new \Phplrt\Parser\Grammar\Concatenation([57, 23]),
+                new \Phplrt\Parser\Grammar\Concatenation([23, 57]),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_INT, true),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_BRACE_CLOSE, false),
-                new \Phplrt\Parser\Grammar\Repetition(61, 0, \INF),
-                new \Phplrt\Parser\Grammar\Concatenation([62, 28]),
+                new \Phplrt\Parser\Grammar\Repetition(63, 0, \INF),
+                new \Phplrt\Parser\Grammar\Concatenation([64, 28]),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_OR, false),
-                new \Phplrt\Parser\Grammar\Optional(64),
+                new \Phplrt\Parser\Grammar\Optional(66),
                 new \Phplrt\Parser\Grammar\Lexeme(self::T_SEMICOLON, false),
             ],
             initial: 0,
@@ -261,20 +266,21 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
                 15 => self::reduceAnnotation(...),
                 27 => self::reduceAlternation(...),
                 28 => self::reduceConcatenation(...),
-                29 => self::reduceElement(...),
-                34 => self::reduceSuffixed(...),
-                37 => self::reduceKeptTokenReference(...),
-                40 => self::reduceSkippedTokenReference(...),
-                42 => self::reduceRuleReference(...),
-                44 => self::reduceInlineValue(...),
-                45 => self::reduceInlinePattern(...),
-                48 => self::reduceZeroOrOne(...),
-                49 => self::reduceOneOrMore(...),
-                50 => self::reduceZeroOrMore(...),
-                54 => self::reduceRangeFromTo(...),
-                56 => self::reduceRangeFrom(...),
-                57 => self::reduceRangeTo(...),
-                58 => self::reduceRangeExactly(...),
+                30 => self::reduceAdjacency(...),
+                31 => self::reduceElement(...),
+                36 => self::reduceSuffixed(...),
+                39 => self::reduceKeptTokenReference(...),
+                42 => self::reduceSkippedTokenReference(...),
+                44 => self::reduceRuleReference(...),
+                46 => self::reduceInlineValue(...),
+                47 => self::reduceInlinePattern(...),
+                50 => self::reduceZeroOrOne(...),
+                51 => self::reduceOneOrMore(...),
+                52 => self::reduceZeroOrMore(...),
+                56 => self::reduceRangeFromTo(...),
+                58 => self::reduceRangeFrom(...),
+                59 => self::reduceRangeTo(...),
+                60 => self::reduceRangeExactly(...),
             ],
             lookahead: [
                 null,
@@ -364,15 +370,6 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
                     28 => true,
                     true,
                     true,
-                ],
-                [
-                    9 => true,
-                    11 => true,
-                    20 => true,
-                    true,
-                    26 => true,
-                    28 => true,
-                    true,
                     true,
                 ],
                 [
@@ -384,6 +381,31 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
                     28 => true,
                     true,
                     true,
+                    true,
+                ],
+                [
+                    9 => true,
+                    11 => true,
+                    20 => true,
+                    true,
+                    26 => true,
+                    28 => true,
+                    true,
+                    true,
+                    true,
+                ],
+                [
+                    30 => true,
+                ],
+                [
+                    9 => true,
+                    11 => true,
+                    20 => true,
+                    true,
+                    26 => true,
+                    28 => true,
+                    true,
+                    31 => true,
                 ],
                 null,
                 [
@@ -402,7 +424,7 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
                     20 => true,
                     true,
                     26 => true,
-                    30 => true,
+                    31 => true,
                 ],
                 [
                     9 => true,
@@ -410,7 +432,7 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
                     20 => true,
                     true,
                     26 => true,
-                    30 => true,
+                    31 => true,
                 ],
                 [
                     9 => true,
@@ -435,13 +457,13 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
                 ],
                 [
                     20 => true,
-                    30 => true,
+                    31 => true,
                 ],
                 [
                     20 => true,
                 ],
                 [
-                    30 => true,
+                    31 => true,
                 ],
                 null,
                 [
@@ -529,6 +551,8 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
                 false,
                 true,
                 true,
+                false,
+                true,
                 true,
                 false,
                 false,
@@ -598,64 +622,93 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
                         4,
                     ],
                 ],
-                31 => [
-                    28 => [
-                        32,
+                29 => [
+                    30 => [
+                        30,
                     ],
-                    [
-                        33,
-                    ],
-                ],
-                35 => [
                     9 => [
-                        36,
+                        31,
                     ],
                     11 => [
-                        37,
+                        31,
                     ],
-                    26 => [
-                        40,
+                    20 => [
+                        31,
                     ],
                     21 => [
-                        42,
+                        31,
                     ],
-                    20 => [
-                        43,
+                    26 => [
+                        31,
                     ],
-                    30 => [
-                        43,
+                    28 => [
+                        31,
+                    ],
+                    29 => [
+                        31,
+                    ],
+                    [
+                        31,
                     ],
                 ],
-                43 => [
-                    20 => [
+                33 => [
+                    28 => [
+                        34,
+                    ],
+                    [
+                        35,
+                    ],
+                ],
+                37 => [
+                    9 => [
+                        38,
+                    ],
+                    11 => [
+                        39,
+                    ],
+                    26 => [
+                        42,
+                    ],
+                    21 => [
                         44,
                     ],
-                    30 => [
+                    20 => [
+                        45,
+                    ],
+                    31 => [
                         45,
                     ],
                 ],
-                47 => [
+                45 => [
+                    20 => [
+                        46,
+                    ],
+                    31 => [
+                        47,
+                    ],
+                ],
+                49 => [
                     13 => [
-                        48,
-                    ],
-                    [
-                        49,
-                    ],
-                    [
                         50,
                     ],
                     [
                         51,
                     ],
+                    [
+                        52,
+                    ],
+                    [
+                        53,
+                    ],
                 ],
-                53 => [
+                55 => [
                     19 => [
-                        54,
                         56,
                         58,
+                        60,
                     ],
                     18 => [
-                        57,
+                        59,
                     ],
                 ],
             ],
@@ -690,6 +743,7 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
                 'T_COLON',
                 'T_AMPERSAND',
                 'T_EXCLAMATION',
+                'T_TILDE',
                 'T_REGEX',
                 '/[^\\s]++/',
             ],
@@ -1043,6 +1097,16 @@ final class PP3Parser implements \Phplrt\Contracts\Parser\ParserInterface
             statements: $statements,
             offset: $statements[0]->offset,
             length: \max(0, $last->offset + $last->length - $statements[0]->offset),
+        );
+    }
+
+    private static function reduceAdjacency(\Phplrt\Parser\Context $ctx, mixed $children): mixed
+    {
+        \assert($children instanceof \Phplrt\Lexer\Token\Token);
+
+        return new \Phplrt\Compiler\Node\Statement\Adjacency(
+            offset: $children->offset,
+            length: $children->size,
         );
     }
 

--- a/libs/components/compiler/tests/PP3AdjacencyTest.php
+++ b/libs/components/compiler/tests/PP3AdjacencyTest.php
@@ -121,22 +121,9 @@ final class PP3AdjacencyTest extends TestCase
             PP3);
     }
 
-    public function testAReferenceToASkippedTokenNamesTheWaysOut(): void
-    {
-        Expect::exception(ParserCompilerException::class)
-            ->withMessageContaining('Write "~" between the statements');
-
-        self::compile(<<<'PP3'
-            %skip  T_WHITESPACE  \s++
-            %token T_NAME        \w++
-
-            Pair : <T_NAME> ::T_WHITESPACE:: <T_NAME> ;
-            PP3);
-    }
-
     public function testAdjacencyIsWrittenDownAsSourceCode(): void
     {
-        $code = (string) new Compiler()
+        $code = (string) (new Compiler())
             ->load(StringSource::createFromString(<<<'PP3'
                 %token T_NAME  \w++
                 %token T_DOT   \.

--- a/libs/components/compiler/tests/PP3AdjacencyTest.php
+++ b/libs/components/compiler/tests/PP3AdjacencyTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phplrt\Compiler\Tests;
+
+use Phplrt\Compiler\Compiler;
+use Phplrt\Contracts\Parser\ParserInterface;
+use Phplrt\Parser\Builder\Exception\ParserCompilerException;
+use Phplrt\Parser\Exception\UnexpectedTokenException;
+use Phplrt\Source\StringSource;
+use Testo\Assert;
+use Testo\Expect;
+use Testo\Filter\Group;
+use Testo\Test;
+
+#[Group('phplrt/compiler')]
+#[Test]
+final class PP3AdjacencyTest extends TestCase
+{
+    private const NAMESPACES = <<<'PP3'
+        %skip  T_WHITESPACE     \s++
+        %token T_NAME           \w++
+        %token T_NS_SEPARATOR   \\
+
+        Namespaces -> { return $children; }
+          : Namespace()+
+          ;
+
+        Namespace -> {
+            $result = '';
+
+            foreach ((array) $children as $token) {
+                $result .= $token->value;
+            }
+
+            return $result;
+        }
+          : ::T_NS_SEPARATOR:: ~ Relative()
+          | Relative()
+          ;
+
+        Relative : (<T_NAME> ~ ::T_NS_SEPARATOR:: ~)* <T_NAME> ;
+        PP3;
+
+    public function testASpaceEndsAName(): void
+    {
+        $parser = self::compile(self::NAMESPACES);
+
+        Assert::same(
+            $parser->parse(StringSource::createFromString('Some\Any \Ololo\Trololo')),
+            ['SomeAny', 'OloloTrololo'],
+        );
+    }
+
+    public function testAQualifiedNameIsReadAsAWhole(): void
+    {
+        $parser = self::compile(self::NAMESPACES);
+
+        Assert::same($parser->parse(StringSource::createFromString('Some\Any\More')), ['SomeAnyMore']);
+    }
+
+    public function testALeadingSeparatorBelongsToTheNameAfterIt(): void
+    {
+        $parser = self::compile(self::NAMESPACES);
+
+        Assert::same($parser->parse(StringSource::createFromString('\A \B')), ['A', 'B']);
+    }
+
+    public function testASeparatorWrittenApartIsNotRead(): void
+    {
+        $parser = self::compile(self::NAMESPACES);
+
+        Expect::exception(UnexpectedTokenException::class);
+
+        $parser->parse(StringSource::createFromString('A \ B'));
+    }
+
+    public function testACommentIsWrittenInBetween(): void
+    {
+        $parser = self::compile(<<<'PP3'
+            %skip  T_COMMENT  /\*.*?\*/
+            %token T_NAME     \w++
+            %token T_DOT      \.
+
+            Pair -> { return 'ok'; }
+              : <T_NAME> ~ ::T_DOT:: ~ <T_NAME>
+              ;
+            PP3);
+
+        Assert::same($parser->parse(StringSource::createFromString('a.b')), 'ok');
+
+        Expect::exception(UnexpectedTokenException::class);
+
+        $parser->parse(StringSource::createFromString('a/* here */.b'));
+    }
+
+    public function testAdjacencyAfterAnOptionalStatementIsReported(): void
+    {
+        Expect::exception(ParserCompilerException::class)
+            ->withMessageContaining('may be recognized without reading one');
+
+        self::compile(<<<'PP3'
+            %token T_NAME  \w++
+            %token T_DOT   \.
+
+            Pair : <T_NAME>? ~ ::T_DOT:: ;
+            PP3);
+    }
+
+    public function testAdjacencyOpeningARuleIsReported(): void
+    {
+        Expect::exception(ParserCompilerException::class)
+            ->withMessageContaining('it cannot open the sequence');
+
+        self::compile(<<<'PP3'
+            %token T_NAME  \w++
+            %token T_DOT   \.
+
+            Pair : ~ <T_NAME> ::T_DOT:: ;
+            PP3);
+    }
+
+    public function testAReferenceToASkippedTokenNamesTheWaysOut(): void
+    {
+        Expect::exception(ParserCompilerException::class)
+            ->withMessageContaining('Write "~" between the statements');
+
+        self::compile(<<<'PP3'
+            %skip  T_WHITESPACE  \s++
+            %token T_NAME        \w++
+
+            Pair : <T_NAME> ::T_WHITESPACE:: <T_NAME> ;
+            PP3);
+    }
+
+    public function testAdjacencyIsWrittenDownAsSourceCode(): void
+    {
+        $code = (string) new Compiler()
+            ->load(StringSource::createFromString(<<<'PP3'
+                %token T_NAME  \w++
+                %token T_DOT   \.
+
+                Pair : <T_NAME> ~ ::T_DOT:: ;
+                PP3))
+            ->generate();
+
+        Assert::string($code)
+            ->contains('\Phplrt\Parser\Grammar\Adjacency(true)');
+    }
+
+    private static function compile(string $grammar): ParserInterface
+    {
+        $compiler = new Compiler();
+        $compiler->load(StringSource::createFromString($grammar));
+
+        return $compiler->getParser();
+    }
+}

--- a/libs/components/compiler/tests/TestCase.php
+++ b/libs/components/compiler/tests/TestCase.php
@@ -61,6 +61,7 @@ abstract class TestCase
                 ? \sprintf('<%s>', $node->name)
                 : \sprintf('::%s::', $node->name),
             $node instanceof Statement\RuleReference => \sprintf('%s()', $node->name),
+            $node instanceof Statement\Adjacency => $node->isExpected ? '~' : '!~',
             $node instanceof Statement\InlinePattern => \sprintf('"%s"', $node->pattern),
         };
     }

--- a/libs/components/parser-builder/src/Analysis/LookaheadConstructionParserAnalysisPass.php
+++ b/libs/components/parser-builder/src/Analysis/LookaheadConstructionParserAnalysisPass.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phplrt\Parser\Builder\Analysis;
 
+use Phplrt\Parser\Grammar\Adjacency;
 use Phplrt\Parser\Grammar\Alternation;
 use Phplrt\Parser\Grammar\Concatenation;
 use Phplrt\Parser\Grammar\Lexeme;
@@ -146,6 +147,7 @@ final class LookaheadConstructionParserAnalysisPass implements
                 break;
 
             case $definition instanceof Predicate:
+            case $definition instanceof Adjacency:
                 /**
                  * A predicate reads nothing, so it begins with no token at all
                  * and the rule behind it decides what comes first.

--- a/libs/components/parser-builder/src/Compiler/AdjacencyPositionValidationParserCompilerPass.php
+++ b/libs/components/parser-builder/src/Compiler/AdjacencyPositionValidationParserCompilerPass.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phplrt\Parser\Builder\Compiler;
+
+use Phplrt\Lexer\Builder\LexerBuilderResult;
+use Phplrt\Parser\Builder\Definition\AdjacencyRuleDefinition;
+use Phplrt\Parser\Builder\Definition\ConcatenationRuleDefinition;
+use Phplrt\Parser\Builder\Definition\RuleDefinition;
+use Phplrt\Parser\Builder\Exception\CompilationFailedException;
+
+/**
+ * Checks that every requirement of adjacency has a token behind it.
+ *
+ * Such a rule answers whether the token behind it ends where the token ahead of
+ * it begins, so it describes a pair. The token ahead is always there, the end
+ * of the input being a token of its own, while the one behind is only there
+ * once something before the rule has read it: written where nothing has, the
+ * rule would compare the input against whatever happens to stand there, which
+ * is a token belonging to somebody else.
+ *
+ * A statement that may be recognized without reading a token is the same case,
+ * only found out later: the pair it belongs to exists in the grammar and is
+ * gone from the input.
+ *
+ * Nothing is asked about what follows the rule. A sequence ending with one
+ * describes the pair its own last token makes with whatever comes next, which
+ * is how a repetition says that its every turn is written next to the one
+ * before it.
+ *
+ * @readonly
+ */
+final class AdjacencyPositionValidationParserCompilerPass implements
+    ParserCompilerPassInterface
+{
+    public function process(ParserBuildingContext $context, LexerBuilderResult $lexer): void
+    {
+        $adjacent = [];
+
+        foreach ($context->rules as $rule) {
+            if ($rule instanceof AdjacencyRuleDefinition) {
+                $adjacent[] = $rule;
+            }
+        }
+
+        if ($adjacent === []) {
+            return;
+        }
+
+        $parents = RuleParents::createFromRules($context->rules);
+        $nullable = NullableRules::createFromRules($context->rules);
+
+        foreach ($adjacent as $rule) {
+            $this->validateOrFail($rule, $parents, $nullable);
+        }
+    }
+
+    /**
+     * @throws CompilationFailedException
+     */
+    private function validateOrFail(
+        AdjacencyRuleDefinition $rule,
+        RuleParents $parents,
+        NullableRules $nullable,
+    ): void {
+        $referrers = $parents->findParents($rule);
+
+        if ($referrers === []) {
+            throw new CompilationFailedException($rule, \sprintf(
+                'Rule %s describes a pair of tokens, so it cannot be a rule of its own',
+                $rule,
+            ));
+        }
+
+        foreach ($referrers as $referrer) {
+            if (!$referrer instanceof ConcatenationRuleDefinition) {
+                throw new CompilationFailedException($rule, \sprintf(
+                    'Rule %s describes a pair of tokens, so it may only be written after '
+                        . 'a statement of a sequence, and %s is not one',
+                    $rule,
+                    $referrer->printReference(),
+                ));
+            }
+
+            $this->validatePrecedingOrFail($rule, $referrer, $nullable);
+        }
+    }
+
+    /**
+     * @throws CompilationFailedException
+     */
+    private function validatePrecedingOrFail(
+        AdjacencyRuleDefinition $rule,
+        ConcatenationRuleDefinition $referrer,
+        NullableRules $nullable,
+    ): void {
+        foreach ($referrer->rules as $index => $statement) {
+            if ($statement !== $rule) {
+                continue;
+            }
+
+            if ($index === 0) {
+                throw new CompilationFailedException($rule, \sprintf(
+                    'Rule %s compares the token behind it, so it cannot open the sequence %s: '
+                        . 'the token it would compare belongs to whatever stands before the rule',
+                    $rule,
+                    $referrer->printReference(),
+                ));
+            }
+
+            $this->validateNeighbourOrFail($rule, $referrer, $referrer->rules[$index - 1], $nullable);
+        }
+    }
+
+    /**
+     * @throws CompilationFailedException
+     */
+    private function validateNeighbourOrFail(
+        AdjacencyRuleDefinition $rule,
+        ConcatenationRuleDefinition $referrer,
+        RuleDefinition $neighbour,
+        NullableRules $nullable,
+    ): void {
+        if (!$nullable->isNullable($neighbour)) {
+            return;
+        }
+
+        throw new CompilationFailedException($rule, \sprintf(
+            'Rule %s compares the token behind it, but %s of the sequence %s may be recognized '
+                . 'without reading one, so there may be no such token in the sequence at all. '
+                . 'Write an alternative per case instead, so that every case names the tokens '
+                . 'it compares',
+            $rule,
+            $neighbour->printReference(),
+            $referrer->printReference(),
+        ));
+    }
+}

--- a/libs/components/parser-builder/src/Compiler/NullableRules.php
+++ b/libs/components/parser-builder/src/Compiler/NullableRules.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phplrt\Parser\Builder\Compiler;
 
+use Phplrt\Parser\Builder\Definition\AdjacencyRuleDefinition;
 use Phplrt\Parser\Builder\Definition\AlternationRuleDefinition;
 use Phplrt\Parser\Builder\Definition\ConcatenationRuleDefinition;
 use Phplrt\Parser\Builder\Definition\OptionalRuleDefinition;
@@ -88,7 +89,8 @@ final class NullableRules
 
         return match (true) {
             $rule instanceof OptionalRuleDefinition,
-            $rule instanceof PredicateRuleDefinition => true,
+            $rule instanceof PredicateRuleDefinition,
+            $rule instanceof AdjacencyRuleDefinition => true,
             $rule instanceof RepetitionRuleDefinition => $rule->min === 0
                 || $nullable[$rule->rule] === true,
             default => false,

--- a/libs/components/parser-builder/src/Definition/AdjacencyRuleDefinition.php
+++ b/libs/components/parser-builder/src/Definition/AdjacencyRuleDefinition.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phplrt\Parser\Builder\Definition;
+
+/**
+ * Requires the surrounding tokens to be written one right after another.
+ */
+final class AdjacencyRuleDefinition extends RuleDefinition
+{
+    /**
+     * @param non-empty-string|null $name
+     */
+    public function __construct(
+        /**
+         * Contains {@see true} in case of the tokens must be written with nothing
+         * in between, or {@see false} in case of they must not
+         *
+         * @phpstan-readonly-allow-private-mutation
+         */
+        public bool $isExpected = true,
+        ?string $name = null,
+    ) {
+        parent::__construct($name);
+    }
+
+    /**
+     * Requires the tokens around the rule to be written with nothing in
+     * between.
+     *
+     * @api
+     *
+     * @return $this
+     */
+    public function expect(): self
+    {
+        return $this->setExpected();
+    }
+
+    /**
+     * Requires something to be written between the tokens around the rule.
+     *
+     * @api
+     *
+     * @return $this
+     */
+    public function reject(): self
+    {
+        return $this->setExpected(false);
+    }
+
+    /**
+     * @api
+     *
+     * @return $this
+     */
+    public function setExpected(bool $expected = true): self
+    {
+        $this->isExpected = $expected;
+
+        return $this;
+    }
+
+    protected function printValue(): string
+    {
+        return $this->isExpected ? '~' : '!~';
+    }
+}

--- a/libs/components/parser-builder/src/ParserBuilder.php
+++ b/libs/components/parser-builder/src/ParserBuilder.php
@@ -11,6 +11,7 @@ use Phplrt\Parser\Builder\Analysis\KeptRuleConstructionParserAnalysisPass;
 use Phplrt\Parser\Builder\Analysis\LookaheadConstructionParserAnalysisPass;
 use Phplrt\Parser\Builder\Analysis\ParserAnalysisPassInterface;
 use Phplrt\Parser\Builder\Analysis\ParserResultContext;
+use Phplrt\Parser\Builder\Compiler\AdjacencyPositionValidationParserCompilerPass;
 use Phplrt\Parser\Builder\Compiler\DuplicateRuleParserCompilerPass;
 use Phplrt\Parser\Builder\Compiler\InitialRuleParserCompilerPass;
 use Phplrt\Parser\Builder\Compiler\LeftRecursionValidationParserCompilerPass;
@@ -26,6 +27,7 @@ use Phplrt\Parser\Builder\Compiler\RuleReferenceResolutionParserCompilerPass;
 use Phplrt\Parser\Builder\Compiler\TokenReferenceValidationParserCompilerPass;
 use Phplrt\Parser\Builder\Compiler\UnreachableRuleParserCompilerPass;
 use Phplrt\Parser\Builder\Compiler\UnreportableMessageParserCompilerPass;
+use Phplrt\Parser\Builder\Definition\AdjacencyRuleDefinition;
 use Phplrt\Parser\Builder\Definition\AlternationRuleDefinition;
 use Phplrt\Parser\Builder\Definition\ConcatenationRuleDefinition;
 use Phplrt\Parser\Builder\Definition\OptionalRuleDefinition;
@@ -150,6 +152,7 @@ final class ParserBuilder implements LoggerAwareInterface
             self::PASS_PRIORITY_CHECK => [
                 new TokenReferenceValidationParserCompilerPass(),
                 new ProductionValidationParserCompilerPass(),
+                new AdjacencyPositionValidationParserCompilerPass(),
                 new LeftRecursionValidationParserCompilerPass(),
             ],
             self::PASS_PRIORITY_OPTIMIZE => [
@@ -325,6 +328,36 @@ final class ParserBuilder implements LoggerAwareInterface
         ?string $name = null,
     ): PredicateRuleDefinition {
         $definition = new PredicateRuleDefinition($rule, $isExpected, $name);
+
+        $this->addRule($definition);
+
+        return $definition;
+    }
+
+    /**
+     * Adds the requirement for the surrounding tokens to be written one right
+     * after another.
+     *
+     * The rule reads nothing and only answers whether the token behind it ends
+     * exactly where the token ahead of it begins, which is what tells a name
+     * written as "a\b" from the two names written as "a \b".
+     *
+     * ```php
+     * // A name and a separator with nothing written in between
+     * $parser->addConcatenation([
+     *     $parser->addTokenReference('T_NAME'),
+     *     $parser->addAdjacency(),
+     *     $parser->addTokenReference('T_SEPARATOR'),
+     * ]);
+     * ```
+     *
+     * @api
+     *
+     * @param non-empty-string|null $name
+     */
+    public function addAdjacency(bool $isExpected = true, ?string $name = null): AdjacencyRuleDefinition
+    {
+        $definition = new AdjacencyRuleDefinition($isExpected, $name);
 
         $this->addRule($definition);
 

--- a/libs/components/parser-builder/src/Transformer/ParserResultContextTransformer.php
+++ b/libs/components/parser-builder/src/Transformer/ParserResultContextTransformer.php
@@ -7,6 +7,7 @@ namespace Phplrt\Parser\Builder\Transformer;
 use Phplrt\Lexer\Builder\LexerBuilderResult;
 use Phplrt\Parser\Builder\Analysis\ParserResultContext;
 use Phplrt\Parser\Builder\Compiler\ParserBuildingContext;
+use Phplrt\Parser\Builder\Definition\AdjacencyRuleDefinition;
 use Phplrt\Parser\Builder\Definition\AlternationRuleDefinition;
 use Phplrt\Parser\Builder\Definition\ConcatenationRuleDefinition;
 use Phplrt\Parser\Builder\Definition\OptionalRuleDefinition;
@@ -19,6 +20,7 @@ use Phplrt\Parser\Builder\Definition\TokenNameRuleDefinition;
 use Phplrt\Parser\Builder\Definition\TokenRuleDefinition;
 use Phplrt\Parser\Builder\Exception\CompilationFailedException;
 use Phplrt\Parser\Builder\Exception\ParserCompilerException;
+use Phplrt\Parser\Grammar\Adjacency;
 use Phplrt\Parser\Grammar\Alternation;
 use Phplrt\Parser\Grammar\Concatenation;
 use Phplrt\Parser\Grammar\Lexeme;
@@ -156,6 +158,9 @@ final class ParserResultContextTransformer
             ),
             $definition instanceof PredicateRuleDefinition => new Predicate(
                 ruleId: $identifiers[$definition->rule],
+                isExpected: $definition->isExpected,
+            ),
+            $definition instanceof AdjacencyRuleDefinition => new Adjacency(
                 isExpected: $definition->isExpected,
             ),
             $definition instanceof RepetitionRuleDefinition => new Repetition(

--- a/libs/components/parser-builder/tests/AdjacencyTest.php
+++ b/libs/components/parser-builder/tests/AdjacencyTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phplrt\Parser\Builder\Tests;
+
+use Phplrt\Contracts\Parser\ParserInterface;
+use Phplrt\Parser\Builder\Exception\ParserCompilerException;
+use Phplrt\Parser\Builder\ParserBuilder;
+use Phplrt\Parser\Exception\UnexpectedTokenException;
+use Phplrt\Source\StringSource;
+use Testo\Assert;
+use Testo\Expect;
+use Testo\Filter\Group;
+use Testo\Test;
+
+#[Group('phplrt/parser-compiler')]
+#[Test]
+final class AdjacencyTest extends TestCase
+{
+    /**
+     * Root : <T_NUMBER> ~ <T_PLUS> <T_NUMBER> ;
+     */
+    private static function createParserFor(bool $isExpected): ParserInterface
+    {
+        $lexer = self::createLexerBuilder();
+
+        $parser = new ParserBuilder();
+        $parser->setInitialRule($parser->addConcatenation([
+            $parser->addTokenReference('T_NUMBER'),
+            $parser->addAdjacency($isExpected),
+            $parser->addTokenReference('T_PLUS'),
+            $parser->addTokenReference('T_NUMBER'),
+        ], 'Root'));
+
+        return $parser->build($lexer->build())
+            ->toParser(self::createLexer($lexer));
+    }
+
+    public function testTokensWrittenNextToEachOtherAreRecognized(): void
+    {
+        $parser = self::createParserFor(true);
+
+        Assert::same(
+            self::collectValues($parser->parse(StringSource::createFromString('1+2'))),
+            ['1', '+', '2'],
+        );
+    }
+
+    public function testSeparatedTokensAreNotRecognized(): void
+    {
+        $parser = self::createParserFor(true);
+
+        Expect::exception(UnexpectedTokenException::class);
+
+        $parser->parse(StringSource::createFromString('1 + 2'));
+    }
+
+    public function testAdjacencyReadsNothing(): void
+    {
+        $parser = self::createParserFor(true);
+
+        Assert::count(self::collectValues($parser->parse(StringSource::createFromString('1+2'))), 3);
+    }
+
+    public function testSeparatedTokensAreRecognizedWhenTheGapIsRequired(): void
+    {
+        $parser = self::createParserFor(false);
+
+        Assert::same(
+            self::collectValues($parser->parse(StringSource::createFromString('1 + 2'))),
+            ['1', '+', '2'],
+        );
+    }
+
+    public function testTokensWrittenNextToEachOtherAreNotRecognizedWhenTheGapIsRequired(): void
+    {
+        $parser = self::createParserFor(false);
+
+        Expect::exception(UnexpectedTokenException::class);
+
+        $parser->parse(StringSource::createFromString('1+2'));
+    }
+
+    /**
+     * Root : (<T_NUMBER> ~ <T_PLUS> ~)* <T_NUMBER> ;
+     *
+     * A sequence may end with the rule: what it compares is the pair its own
+     * last token makes with whatever the next turn begins with.
+     */
+    public function testAdjacencyClosingARepeatedSequence(): void
+    {
+        $lexer = self::createLexerBuilder();
+
+        $parser = new ParserBuilder();
+        $parser->setInitialRule($parser->addConcatenation([
+            $parser->addRepetition($parser->addConcatenation([
+                $parser->addTokenReference('T_NUMBER'),
+                $parser->addAdjacency(),
+                $parser->addTokenReference('T_PLUS'),
+                $parser->addAdjacency(),
+            ])),
+            $parser->addTokenReference('T_NUMBER'),
+        ], 'Root'));
+
+        $runtime = $parser->build($lexer->build())
+            ->toParser(self::createLexer($lexer));
+
+        Assert::same(
+            self::collectValues($runtime->parse(StringSource::createFromString('1+2+3'))),
+            ['1', '+', '2', '+', '3'],
+        );
+
+        Expect::exception(UnexpectedTokenException::class);
+
+        $runtime->parse(StringSource::createFromString('1+2 +3'));
+    }
+
+    /**
+     * Root : <T_NUMBER> ~ <T_MINUS> | <T_NUMBER> <T_MINUS> ;
+     *
+     * The rule reads nothing, so an alternative rejected by it leaves neither
+     * the input nor the trace behind.
+     */
+    public function testRejectedAlternativeLeavesNothingBehind(): void
+    {
+        $lexer = self::createLexerBuilder();
+
+        $parser = new ParserBuilder();
+        $parser->setInitialRule($parser->addAlternation([
+            $parser->addConcatenation([
+                $parser->addTokenReference('T_NUMBER'),
+                $parser->addAdjacency(),
+                $parser->addTokenReference('T_MINUS'),
+            ]),
+            $parser->addConcatenation([
+                $parser->addTokenReference('T_NUMBER'),
+                $parser->addTokenReference('T_MINUS'),
+            ]),
+        ], 'Root'));
+
+        $runtime = $parser->build($lexer->build())
+            ->toParser(self::createLexer($lexer));
+
+        Assert::same(
+            self::collectValues($runtime->parse(StringSource::createFromString('1 -'))),
+            ['1', '-'],
+        );
+    }
+
+    public function testGrammar(): void
+    {
+        $lexer = self::createLexerBuilder();
+
+        $parser = new ParserBuilder();
+        $parser->setInitialRule($parser->addConcatenation([
+            $parser->addTokenReference('T_NUMBER'),
+            $parser->addAdjacency(isExpected: false),
+            $parser->addTokenReference('T_PLUS'),
+        ], 'Root'));
+
+        Assert::same(self::describe($parser->build($lexer->build())), [
+            '0: Concatenation(1, 2, 3)',
+            '1: Lexeme(1, keep)',
+            '2: Adjacency(reject)',
+            '3: Lexeme(2, keep)',
+        ]);
+    }
+
+    public function testAdjacencyOpeningASequenceIsReported(): void
+    {
+        $parser = new ParserBuilder();
+        $parser->setInitialRule($parser->addConcatenation([
+            $parser->addAdjacency(),
+            $parser->addTokenReference('T_NUMBER'),
+        ], 'Root'));
+
+        Expect::exception(ParserCompilerException::class)
+        ->withMessageContaining('it cannot open the sequence');
+
+        $parser->build(self::createLexerBuilder()->build());
+    }
+
+    public function testNullableStatementBeforeAdjacencyIsReported(): void
+    {
+        $parser = new ParserBuilder();
+        $parser->setInitialRule($parser->addConcatenation([
+            $parser->addTokenReference('T_NUMBER'),
+            $parser->addOptional($parser->addTokenReference('T_PLUS')),
+            $parser->addAdjacency(),
+            $parser->addTokenReference('T_NUMBER'),
+        ], 'Root'));
+
+        Expect::exception(ParserCompilerException::class)
+        ->withMessageContaining('may be recognized without reading one');
+
+        $parser->build(self::createLexerBuilder()->build());
+    }
+
+    public function testAdjacencyAsARuleOfItsOwnIsReported(): void
+    {
+        $parser = new ParserBuilder();
+        $parser->setInitialRule($parser->addAdjacency(name: 'Root'));
+
+        Expect::exception(ParserCompilerException::class)
+        ->withMessageContaining('cannot be a rule of its own');
+
+        $parser->build(self::createLexerBuilder()->build());
+    }
+
+    public function testAdjacencyOutsideOfASequenceIsReported(): void
+    {
+        $parser = new ParserBuilder();
+        $parser->setInitialRule($parser->addRepetition(
+            $parser->addAdjacency(),
+            min: 1,
+            name: 'Root',
+        ));
+
+        Expect::exception(ParserCompilerException::class)
+        ->withMessageContaining('may only be written after a statement of a sequence');
+
+        $parser->build(self::createLexerBuilder()->build());
+    }
+}

--- a/libs/components/parser-builder/tests/TestCase.php
+++ b/libs/components/parser-builder/tests/TestCase.php
@@ -11,6 +11,7 @@ use Phplrt\Lexer\Builder\LexerBuilder;
 use Phplrt\Lexer\Builder\Transformer\RuntimeLexerTransformer;
 use Phplrt\Parser\Builder\ParserBuilder;
 use Phplrt\Parser\Builder\ParserBuilderResult;
+use Phplrt\Parser\Grammar\Adjacency;
 use Phplrt\Parser\Grammar\Alternation;
 use Phplrt\Parser\Grammar\Concatenation;
 use Phplrt\Parser\Grammar\Lexeme;
@@ -89,6 +90,7 @@ abstract class TestCase
                 $rule->isExpected ? 'expect' : 'reject',
             ),
             $rule instanceof Repetition => \sprintf('Repetition(%d, %d, %s)', $rule->ruleId, $rule->min, $rule->max),
+            $rule instanceof Adjacency => \sprintf('Adjacency(%s)', $rule->isExpected ? 'expect' : 'reject'),
             default => $rule::class,
         };
     }

--- a/libs/components/parser/src/Grammar/Adjacency.php
+++ b/libs/components/parser/src/Grammar/Adjacency.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phplrt\Parser\Grammar;
+
+/**
+ * Requires the surrounding tokens to be written one right after another.
+ *
+ * A lexer reports what it has read and says nothing about what it has stepped
+ * over in between, so a stream of tokens tells "a\b" and "a \ b" apart by
+ * nothing: both of them are the very same three tokens. This is the rule that
+ * tells them apart. It reads nothing of its own and only answers whether the
+ * token behind it ends exactly where the token ahead of it begins.
+ *
+ * For example, a name written of the parts nothing stands between, where #1
+ * recognizes a name and #2 a separator:
+ * ```php
+ * new Concatenation([
+ *     1, // Lexeme(T_NAME)
+ *     3, // Adjacency()
+ *     2, // Lexeme(T_SEPARATOR)
+ * ]);
+ * ```
+ *
+ * The very same rule written in pp3, where "~" means the tokens around it are
+ * written with nothing in between:
+ * ```pp3
+ * Rule : <T_NAME> ~ ::T_SEPARATOR:: ;
+ * ```
+ *
+ * The answer is read off the source rather than off the stream, so it does not
+ * depend on what has been written in between: a space a lexer never reports and
+ * a comment it reports on a channel of its own are both something written
+ * there.
+ *
+ * Note: A rule of this kind reads no input, so it recognizes the empty input
+ *       the way a predicate does. The only question is whether it recognizes
+ *       it here:
+ *
+ * ```math
+ * L(\sim) = \{\, \varepsilon \,\}
+ * ```
+ *
+ * @readonly
+ */
+final class Adjacency implements TerminalInterface
+{
+    public function __construct(
+        /**
+         * Contains {@see true} in case of the tokens must be written with
+         * nothing in between, or {@see false} in case of they must not.
+         */
+        public readonly bool $isExpected = true,
+    ) {}
+}

--- a/libs/components/parser/src/Internal/Buffer/ArrayBuffer.php
+++ b/libs/components/parser/src/Internal/Buffer/ArrayBuffer.php
@@ -76,6 +76,16 @@ final class ArrayBuffer implements BufferInterface
         $this->current = $this->tokens[$offset];
     }
 
+    /**
+     * Gets previous token
+     */
+    public function lookBehind(): TokenInterface
+    {
+        \assert($this->key > 0, 'There is no token behind the beginning of the input');
+
+        return $this->tokens[$this->key - 1];
+    }
+
     public function next(): void
     {
         $next = $this->key + 1;

--- a/libs/components/parser/src/Internal/Buffer/BufferInterface.php
+++ b/libs/components/parser/src/Internal/Buffer/BufferInterface.php
@@ -30,6 +30,13 @@ interface BufferInterface
     public function seek(int $offset): void;
 
     /**
+     * Gets the token right before the current one, without moving the cursor.
+     *
+     * @return TToken
+     */
+    public function lookBehind(): TokenInterface;
+
+    /**
      * Moves the cursor to the next token. Once the input has been read to its
      * end the cursor just stays on the terminal token.
      */

--- a/libs/components/parser/src/Internal/Tracing/RecursiveDescentTracer.php
+++ b/libs/components/parser/src/Internal/Tracing/RecursiveDescentTracer.php
@@ -6,6 +6,7 @@ namespace Phplrt\Parser\Internal\Tracing;
 
 use Phplrt\Contracts\Lexer\Channel;
 use Phplrt\Contracts\Lexer\TokenInterface;
+use Phplrt\Parser\Grammar\Adjacency;
 use Phplrt\Parser\Grammar\Alternation;
 use Phplrt\Parser\Grammar\Concatenation;
 use Phplrt\Parser\Grammar\Lexeme;
@@ -209,6 +210,7 @@ final class RecursiveDescentTracer
             $definition instanceof Optional => $this->matchOptional($definition),
             $definition instanceof Repetition => $this->matchRepetition($definition),
             $definition instanceof Predicate => $this->matchPredicate($definition),
+            $definition instanceof Adjacency => $this->matchAdjacency($definition),
             default => throw new \LogicException(\sprintf(
                 'Unsupported grammar rule %s',
                 \get_debug_type($definition),
@@ -338,6 +340,21 @@ final class RecursiveDescentTracer
         $this->length = $mark;
 
         return $matched === $rule->isExpected;
+    }
+
+    /**
+     * Note: The rule reads nothing, so neither the input nor the trace moves,
+     *       and there is nothing to roll back afterward.
+     */
+    private function matchAdjacency(Adjacency $rule): bool
+    {
+        $buffer = $this->buffer;
+
+        $previous = $buffer->lookBehind();
+        $current = $buffer->current;
+
+        return ($previous->offset + $previous->size === $current->offset)
+            === $rule->isExpected;
     }
 
     private function matchRepetition(Repetition $rule): bool


### PR DESCRIPTION
A `~` between 2 statements says that their tokens are written with **nothing in between**

```
Pair
  // defines: Name [no whitespaces] "." [no whitespaces] Name
  // - `a.b` matches
  // - `a .b` does not
  : <T_NAME> ~ ::T_DOT:: ~ <T_NAME>
  ;
```

Modifies:
- Parser runtime
- Parser builder
- Compiler (add `~` operator in PP3 grammar)

Documentation: https://github.com/phplrt/docs/pull/8